### PR TITLE
$isolated

### DIFF
--- a/API.md
+++ b/API.md
@@ -404,6 +404,7 @@ Kitten.sortAdapter('name -email');
 Updates multiple documents and returns the count of modified documents where:
 
 - `filter` - a filter object used to select the documents to update.
+    - `$isolated` -  Default [`$isolated`](https://docs.mongodb.com/manual/reference/operator/update/isolated/) is set to 1, add $isolated: 0 to filter to disable
 - `update` - the update operations object.
 - `options` - an options object passed to MongoDB's native
   [`updateMany`](https://docs.mongodb.com/manual/reference/method/db.collection.updateMany/)
@@ -421,6 +422,7 @@ Updates multiple documents and returns the count of modified documents where:
 Updates a document and returns the count of modified documents where:
 
 - `filter` - a filter object used to select the document to update.
+    - `$isolated` -  Default [`$isolated`](https://docs.mongodb.com/manual/reference/operator/update/isolated/) is set to 1, add $isolated: 0 to filter to disable
 - `update` - the update operations object.
 - `options` - an options object passed to MongoDB's native
   [`updateOne`](https://docs.mongodb.com/manual/reference/method/db.collection.updateOne/)

--- a/index.js
+++ b/index.js
@@ -389,7 +389,7 @@ class MongoModels {
         let filter;
 
         try {
-            filter = { _id: this._idClass(id) };
+            filter = { _id: this._idClass(id) , $isolated : 1 };
         }
         catch (exception) {
             return callback(exception);
@@ -466,6 +466,10 @@ class MongoModels {
         const callback = args.pop();
         const options = Hoek.applyToDefaults({}, args.pop() || {});
 
+        if (!filter.$isolated) {
+            filter.$isolated = 1;
+        }
+
         args.push(filter);
         args.push(update);
         args.push(options);
@@ -494,6 +498,10 @@ class MongoModels {
         const update = args.shift();
         const callback = args.pop();
         const options = Hoek.applyToDefaults({}, args.pop() || {});
+
+        if (!filter.$isolated) {
+            filter.$isolated = 1;
+        }
 
         args.push(filter);
         args.push(update);

--- a/test/index.js
+++ b/test/index.js
@@ -576,6 +576,45 @@ lab.experiment('MongoModels Proxied Methods', () => {
         });
     });
 
+    lab.test('it updates a document and returns the results ($isolated)', (done) => {
+
+        Async.auto({
+            setup: function (cb) {
+
+                const testDocs = [
+                    { name: 'Ren' },
+                    { name: 'Stimpy' },
+                    { name: 'Yak' }
+                ];
+
+                SubModel.insertMany(testDocs, cb);
+            }
+        }, (err, results) => {
+
+            if (err) {
+                return done(err);
+            }
+
+            const filter = {
+                _id: results.setup[0]._id,
+                $isolated: 1
+            };
+            const update = {
+                $set: { isCool: true }
+            };
+
+            SubModel.updateOne(filter, update, (err, count, result) => {
+
+                Code.expect(err).to.not.exist();
+                Code.expect(count).to.be.a.number();
+                Code.expect(count).to.equal(1);
+                Code.expect(result).to.be.an.object();
+
+                done(err);
+            });
+        });
+    });
+
 
     lab.test('it updates a document and returns the results (with options)', (done) => {
 
@@ -692,6 +731,42 @@ lab.experiment('MongoModels Proxied Methods', () => {
             });
         });
     });
+
+    lab.test('it updates many documents and returns the results ($isolated)', (done) => {
+
+        Async.auto({
+            setup: function (cb) {
+
+                const testDocs = [
+                    { name: 'Ren' },
+                    { name: 'Stimpy' },
+                    { name: 'Yak' }
+                ];
+
+                SubModel.insertMany(testDocs, cb);
+            }
+        }, (err, results) => {
+
+            if (err) {
+                return done(err);
+            }
+
+            const filter = { $isolated: 1 };
+            const update = { $set: { isCool: true } };
+
+            SubModel.updateMany(filter, update, (err, count, result) => {
+
+                Code.expect(err).to.not.exist();
+                Code.expect(count).to.be.a.number();
+                Code.expect(count).to.equal(3);
+                Code.expect(result).to.be.an.object();
+
+                done(err);
+            });
+        });
+    });
+
+
 
 
     lab.test('it updates many documents and returns the results (with options)', (done) => {


### PR DESCRIPTION
Prevents a write operation that affects multiple documents from yielding to other reads or writes once the first document is written. By using the $isolated option, you can ensure that no client sees the changes until the operation completes or errors out. [Mongo Docs](https://docs.mongodb.com/manual/reference/operator/update/isolated/)

