### PR TITLE
async/await and multiple db connections

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,9 @@
+sudo: false
 language: node_js
 node_js:
-  - "6"
   - "8"
+  - "9"
 services:
   - mongodb
-env:
-  - NODE_ENV=test
-before_install:
-  - "sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10"
-  - "echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | sudo tee /etc/apt/sources.list.d/mongodb.list"
-  - "sudo apt-get update"
-  - "sudo apt-get install mongodb-org-server"
 before_script:
   - "until nc -z localhost 27017; do echo Waiting for MongoDB; sleep 1; done"

--- a/API.md
+++ b/API.md
@@ -418,7 +418,7 @@ See: https://github.com/hapijs/joi/blob/master/API.md#validatevalue-schema-optio
 For use with multiple named connections (See: [`connect(connection, [options],
 [name])`](#async-connectconnection-options-name)).
 
-Returns an object containing subset of the model's methods bound to the named
+Returns an object containing a subset of the model's methods bound to the named
 connection.
 
 Available methods include:

--- a/API.md
+++ b/API.md
@@ -309,6 +309,9 @@ Finds documents and returns the results where:
 - `filter` - a filter object used to select the documents.
 - `limit` - a number indicating how many results should be returned.
 - `page` - a number indicating the current page.
+- `options` - an options object passed to MongoDB's native
+  [`Collection.find`](https://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#find)
+  method.
 
 The returned value is an object where:
 

--- a/API.md
+++ b/API.md
@@ -1,239 +1,194 @@
 # API reference
 
+<!-- toc -->
+
 - [Properties](#properties)
   - [`_idClass`](#_idclass)
-  - [`collection`](#collection)
-  - [`ObjectId`](#objectid)
+  - [`collectionName`](#collectionname)
+  - [`ObjectID`](#objectid)
   - [`schema`](#schema)
-  - [`constructWithSchema`](#constructwithschema)
 - [Methods](#methods)
-  - [`connect(uri, options, callback)`](#connectconfig-callback)
-  - [`aggregate(pipeline, [options], callback)`](#aggregatepipeline-options-callback)
-  - [`count(filter, [options], callback)`](#countfilter-options-callback)
-  - [`createIndexes(indexSpecs, [callback])`](#createindexesindexspecs-callback)
-  - [`deleteMany(filter, [options], callback)`](#deletemanyfilter-options-callback)
-  - [`deleteOne(filter, [options], callback)`](#deleteonefilter-options-callback)
-  - [`disconnect()`](#disconnect)
-  - [`distinct(field, [filter], callback)`](#distinctfield-filter-callback)
+  - [`constructor(data)`](#constructordata)
+  - [`async aggregate(pipeline, [options])`](#async-aggregatepipeline-options)
+  - [`collection()`](#collection)
+  - [`async connect(connection, [options], [name])`](#async-connectconnection-options-name)
+  - [`async count(query, [options])`](#async-countquery-options)
+  - [`async createIndexes(indexSpecs)`](#async-createindexesindexspecs)
+  - [`async deleteMany(filter, [options])`](#async-deletemanyfilter-options)
+  - [`async deleteOne(filter, [options])`](#async-deleteonefilter-options)
+  - [`disconnect([name])`](#disconnectname)
+  - [`async distinct(key, query, [options])`](#async-distinctkey-query-options)
   - [`fieldsAdapter(fields)`](#fieldsadapterfields)
-  - [`find(filter, [options], callback)`](#findfilter-options-callback)
-  - [`findById(id, [options], callback)`](#findbyidid-options-callback)
-  - [`findByIdAndDelete(id, callback)`](#findbyidanddeleteid-callback)
-  - [`findByIdAndUpdate(id, update, [options], callback)`](#findbyidandupdateid-update-options-callback)
-  - [`findOne(filter, [options], callback)`](#findonefilter-options-callback)
-  - [`findOneAndDelete(filter, [options], callback)`](#findoneanddeletefilter-options-callback)
-  - [`findOneAndUpdate(filter, update, [options], callback)`](#findoneandupdatefilter-options-callback)
-  - [`insertMany(docs, [options], callback)`](#insertmanydocs-options-callback)
-  - [`insertOne(doc, [options], callback)`](#insertonedoc-options-callback)
-  - [`pagedFind(filter, fields, sort, limit, page, callback)`](#pagedfindfilter-fields-sort-limit-page-callback)
-  - [`replaceOne(filter, doc, [options], callback)`](#replaceonefilter-doc-options-callback)
+  - [`async find(query, [options])`](#async-findquery-options)
+  - [`async findById(id, [options])`](#async-findbyidid-options)
+  - [`async findByIdAndDelete(id)`](#async-findbyidanddeleteid)
+  - [`async findByIdAndUpdate(id, update, [options])`](#async-findbyidandupdateid-update-options)
+  - [`async findOne(query, [options])`](#async-findonequery-options)
+  - [`async findOneAndDelete(filter, [options])`](#async-findoneanddeletefilter-options)
+  - [`async findOneAndReplace(filter, replacement, [options])`](#async-findoneandreplacefilter-replacement-options)
+  - [`async findOneAndUpdate(filter, update, [options])`](#async-findoneandupdatefilter-update-options)
+  - [`async insertMany(docs, [options])`](#async-insertmanydocs-options)
+  - [`async insertOne(doc, [options])`](#async-insertonedoc-options)
+  - [`async pagedFind(filter, limit, page, [options])`](#async-pagedfindfilter-limit-page-options)
+  - [`async replaceOne(filter, doc, [options])`](#async-replaceonefilter-doc-options)
   - [`sortAdapter(sorts)`](#sortadaptersorts)
-  - [`updateMany(filter, update, [options], callback)`](#updatemanyfilter-update-options-callback)
-  - [`updateOne(filter, update, [options], callback)`](#updateonefilter-update-options-callback)
-  - [`validate(callback)`](#validatecallback)
-  - [`validate(input, callback)`](#validateinput-callback)
+  - [`async updateMany(filter, update, [options])`](#async-updatemanyfilter-update-options)
+  - [`async updateOne(filter, update, [options])`](#async-updateonefilter-update-options)
+  - [`validate()`](#validate)
+  - [`validate(input)`](#validateinput)
+  - [`with(name)`](#withname)
 
+<!-- tocstop -->
 
 ## Properties
 
 ### `_idClass`
 
 The type used to cast `_id` properties. Defaults to
-[`MongoDB.ObjectId`](http://docs.mongodb.org/manual/reference/object-id/).
+[`MongoDB.ObjectID`](http://mongodb.github.io/node-mongodb-native/3.0/api/ObjectID.html).
 
 If you wanted to use plain strings for your document `_id` properties you could:
 
 ```js
-Kitten._idClass = String;
+Customer._idClass = String;
 ```
 
-When you define a custom `_idClass` property for your model you just need to
-pass an `_id` parameter of that type when you create new documents.
+When you define a custom `_idClass` property for your model you need to pass an
+`_id` parameter of that type when you create new documents.
 
 ```js
-const data = {
-    _id: 'captain-cute',
-    name: 'Captain Cute'
-};
-
-Kitten.insert(data, (err, results) => {
-
-    // handle response
+const document = new Customer({
+    _id: 'stephen-colbert',
+    name: 'Stephen Colbert'
 });
+
+const customers = await Customer.insertOne(data);
 ```
 
-### `collection`
+### `collectionName`
 
 The name of the collection in MongoDB.
 
 ```js
-Kitten.collection = 'kittens';
+Customer.collectionName = 'customers';
 ```
 
-### `ObjectId`
+### `ObjectID`
 
-An alias to `MongoDB.ObjectId`.
+An alias to
+[`MongoDB.ObjectID`](http://mongodb.github.io/node-mongodb-native/3.0/api/ObjectID.html).
 
 ### `schema`
 
 A `joi` object schema. See: https://github.com/hapijs/joi
 
 ```js
-Kitten.schema = Joi.object().keys({
+Customer.schema = Joi.object({
     _id: Joi.string(),
     name: Joi.string().required(),
     email: Joi.string().required()
 });
 ```
 
-### `constructWithSchema`
-
-A boolean indicating if new instances should be constructed using the schema
-property. Essentially we just call `validate()` during object construction with
-the attributes passed in.
-
-If validation fails, `instance.__err` is populated with the error returned from
-`validate()`.
-
-```js
-class Sloth extends MongoModels {}
-
-Sloth.schema = Joi.object().keys({
-    name: Joi.string().required(),
-    hasHat: Joi.boolean().default(true)
-});
-
-Sloth.constructWithSchema = true;
-
-const fast = new Sloth({
-    name: 'Flash'
-});
-// Sloth { name: 'Flash', hasHat: true }
-
-Boolean(fast.__err);
-// false
-
-const slow = new Sloth({
-    hasHat: false
-});
-// Sloth { hasHat: false }
-
-Boolean(slow.__err);
-// true
-```
-
-
 ## Methods
 
-### `connect(uri, options, callback)`
+### `constructor(data)`
 
-Connects to a MongoDB server where:
+Constructs a new instance of your class using the data provided where:
 
-- `uri` - the connection string passed to `MongoClient.connect`.
+- `data` - an object containing the fields and values of the model instance.
+  Internally `data` is passed to the `validate` function, throwing an error if
+  present or assigning the value (the validated value with any type conversions
+  and other modifiers applied) to the object as properties.
+
+### `async aggregate(pipeline, [options])`
+
+Execute an aggregation framework pipeline against the collection.
+
+- `pipeline` - an array containing all the aggregation framework commands.
+- `options` - an optional options object passed to MongoDB's native
+  [`aggregate`](http://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#aggregate)
+  method.
+
+### `collection()`
+
+Returns the underlying
+[`MongoDB.Collection`](http://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html).
+
+### `async connect(connection, [options], [name])`
+
+Connects to a MongoDB server and returns the
+[`MongoDB.Db`](http://mongodb.github.io/node-mongodb-native/3.0/api/Db.html)
+where:
+
+- `connection` - an object where:
+    - `uri` - the uri of the database. [See uri string
+      docs](https://docs.mongodb.com/manual/reference/connection-string/).
+    - `db` - the name of the database.
 - `options` - an optional object passed to `MongoClient.connect`.
-- `callback` - the callback method using the signature `function (err, db)`
-  where:
-  - `err` - if the connection failed, the error reason, otherwise `null`.
-  - `db` - if the connection succeeded, the initialized db object.
+- `name` - an optional string to identify the connection. Used to support
+  multiple connections along with the [`with(name)`](#withname) method.
+  Defaults to `default`.
 
-### `aggregate(pipeline, [options], callback)`
+### `async count(query, [options])`
 
-Calculates aggregate values for the data in a collection where:
+Returns the number of documents matching a `query` where:
 
-- `pipeline` - A sequence of data aggregation operations or stages.
-- `options` - an options object passed to MongoDB's native
-  [`aggregate`](https://docs.mongodb.com/manual/reference/method/db.collection.aggregate/)
+- `query` - a filter object used to select the documents to count.
+- `options` - an options object passed to the native
+  [`Collection.count`](http://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#count)
   method.
-- `callback` - the callback method using the signature `function (err,
-  results)` where:
-  - `err` - if the query failed, the error reason, otherwise `null`.
-  - `results` - if the query succeeded, an array of documents return from the
-    aggregation.
 
-### `count(filter, [options], callback)`
+### `async createIndexes(indexSpecs)`
 
-Counts documents matching a `filter` where:
-
-- `filter` - a filter object used to select the documents to count.
-- `options` - an options object passed to MongoDB's native
-  [`count`](https://docs.mongodb.com/manual/reference/method/db.collection.count/)
-  method.
-- `callback` - the callback method using the signature `function (err, count)`
-  where:
-  - `err` - if the query failed, the error reason, otherwise `null`.
-  - `count` - if the query succeeded, a number indicating how many documents
-    matched the `filter`.
-
-### `createIndexes(indexSpecs, [callback])`
-
-Note: `createIndexes` is called during plugin registration for each model when
-the `autoIndex` option is set to `true`.
-
-Creates multiple indexes in the collection where:
+Creates multiple indexes in the collection and returns the result where:
 
 - `indexSpecs` - an array of objects containing index specifications to be
-  created.
-- `callback` - the callback method using the signature `function (err, result)`
-  where:
-  - `err` - if creating the indexes failed, the error reason, otherwise `null`.
-  - `result` - if creating the indexes succeeded, the result object.
+  created. [See the index
+  specification](http://docs.mongodb.org/manual/reference/command/createIndexes/)
 
 Indexes are defined as a static property on your models like:
 
 ```js
-Kitten.indexes = [
+Customer.indexes = [
     { key: { name: 1 } },
     { key: { email: -1 } }
 ];
 ```
 
-For details on all the options an index specification may have see:
+### `async deleteMany(filter, [options])`
 
-https://docs.mongodb.org/manual/reference/command/createIndexes/
-
-### `deleteMany(filter, [options], callback)`
-
-Deletes multiple documents and returns the count of deleted documents where:
+Deletes multiple documents and returns the
+[`Collection.deleteWriteOpResult`](http://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#~deleteWriteOpResult)
+where:
 
 - `filter` - a filter object used to select the documents to delete.
 - `options` - an options object passed to MongoDB's native
-  [`deleteMany`](https://docs.mongodb.com/manual/reference/method/db.collection.deleteMany/)
+  [`Collection.deleteMany`](http://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#deleteMany)
   method.
-- `callback` - the callback method using the signature `function (err, count)`
-  where:
-  - `err` - if the query failed, the error reason, otherwise `null`.
-  - `count` - if the query succeeded, a number indicating how many documents
-    were deleted.
 
-### `deleteOne(filter, [options], callback)`
+### `async deleteOne(filter, [options])`
 
-Deletes a document and returns the count of deleted documents where:
+Deletes a document and returns the
+[`Collection.deleteWriteOpResult`](http://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#~deleteWriteOpResult)
+where:
 
 - `filter` - a filter object used to select the document to delete.
 - `options` - an options object passed to MongoDB's native
-  [`deleteOne`](https://docs.mongodb.com/manual/reference/method/db.collection.deleteOne/)
+  [`Collection.deleteOne`](http://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#deleteOne)
   method.
-- `callback` - the callback method using the signature `function (err, count)`
-  where:
-  - `err` - if the query failed, the error reason, otherwise `null`.
-  - `count` - if the query succeeded, a number indicating how many documents
-    were deleted.
 
-### `disconnect()`
+### `disconnect([name])`
 
-Closes the current db connection.
+Closes a specific connection by name or all connections if no name is specified.
 
-### `distinct(field, [filter], callback)`
+### `async distinct(key, query, [options])`
 
-Finds the distinct values for the specified `field`.
+Returns a list of distinct values for the given key across a collection where:
 
-- `field` - a string representing the field for which to return distinct values.
-- `filter` - an optional filter object used to limit the documents distinct applies to.
-- `callback` - the callback method using the signature `function (err, values)`
-  where:
-  - `err` - if the query failed, the error reason, otherwise `null`.
-  - `values` - if the query succeeded, an array of values representing the
-    distinct values for the specified `field`.
+- `key` - a string representing the field for which to return distinct values.
+- `query` - an optional query object used to limit the documents distinct
+  applies to.
 
 ### `fieldsAdapter(fields)`
 
@@ -246,179 +201,142 @@ where:
 Returns a MongoDB friendly fields object.
 
 ```js
-Kitten.fieldsAdapter('name -email');
+Customer.fieldsAdapter('name -email');
 
 // { name: true, email: false }
 ```
 
-### `find(filter, [options], callback)`
+### `async find(query, [options])`
 
-Finds documents where:
+Finds documents and returns an array of model instances where:
 
-- `filter` - a filter object used to select the documents.
+- `query` - a query object used to select the documents.
 - `options` - an options object passed to MongoDB's native
-  [`find`](https://docs.mongodb.com/manual/reference/method/db.collection.find/)
+  [`find`](http://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#find)
   method.
-- `callback` - the callback method using the signature `function (err,
-  results)` where:
-  - `err` - if the query failed, the error reason, otherwise `null`.
-  - `results` - if the query succeeded, an array of documents as class
-    instances.
 
-### `findById(id, [options], callback)`
+### `async findById(id, [options])`
 
-Finds a document by `_id` where:
+Finds a document by `_id` and returns a model instance where:
 
-- `id` - is a string value of the `_id` to find. It will be casted to the type
-  of `_idClass`.
+- `id` - a string value of the `_id` to find. The `id` will be casted to the
+  type of `_idClass`.
 - `options` - an options object passed to MongoDB's native
-  [`findOne`](https://docs.mongodb.com/manual/reference/method/db.collection.findOne/)
+  [`Collection.findOne`](http://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#findOne)
   method.
-- `callback` - the callback method using the signature `function (err, result)`
-  where:
-  - `err` - if the query failed, the error reason, otherwise `null`.
-  - `result` - if the query succeeded, a document as a class instance.
 
-### `findByIdAndDelete(id, callback)`
+### `async findByIdAndDelete(id)`
 
-Finds a document by `_id`, deletes it and returns it where:
+Finds a document by `_id`, deletes it and returns a model instance where:
 
-- `id` - is a string value of the `_id` to find. It will be casted to the type
-  of `_idClass`.
-- `callback` - the callback method using the signature `function (err, result)`
-  where:
-  - `err` - if the query failed, the error reason, otherwise `null`.
-  - `result` - if the query succeeded, a document as a class instance.
+- `id` - a string value of the `_id` to find. The `id` will be casted to the
+  type of `_idClass`.
 
-### `findByIdAndUpdate(id, update, [options], callback)`
+### `async findByIdAndUpdate(id, update, [options])`
 
-Finds a document by `_id`, updates it and returns it where:
+Finds a document by `_id`, updates it and returns a model instance where:
 
-- `id` - is a string value of the `_id` to find. It will be casted to the type
-  of `_idClass`.
+- `id` - a string value of the `_id` to find. The `id` will be casted to the
+  type of `_idClass`.
 - `update` - an object containing the fields/values to be updated.
 - `options` - an optional options object passed to MongoDB's native
-  [`findOneAndUpdate`](https://docs.mongodb.com/manual/reference/method/db.collection.findOneAndUpdate/)
+  [`Collection.findOneAndUpdate`](http://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#findOneAndUpdate)
   method. Defaults to `{ returnOriginal: false }`.
-- `callback` - the callback method using the signature `function (err, result)`
-  where:
-  - `err` - if the query failed, the error reason, otherwise `null`.
-  - `result` - if the query succeeded, a document as a class instance.
 
-### `findOne(filter, [options], callback)`
+### `async findOne(query, [options])`
 
-Finds one document matching a `filter` where:
+Finds one document matching the `query` and returns a model intance where:
 
-- `filter` - a filter object used to select the document.
+- `query` - a filter object used to select the document.
 - `options` - an options object passed to MongoDB's native
-  [`findOne`](https://docs.mongodb.com/manual/reference/method/db.collection.findOne/)
+  [`Collection.findOne`](http://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#findOne)
   method.
-- `callback` - the callback method using the signature `function (err, result)`
-  where:
-  - `err` - if the query failed, the error reason, otherwise `null`.
-  - `result` - if the query succeeded, a document as a class instance.
 
-### `findOneAndDelete(filter, [options], callback)`
+### `async findOneAndDelete(filter, [options])`
 
-Finds one document matching a `filter`, deletes it and returns it where:
+Finds one document matching a `filter`, deletes it and returns a model instance
+where:
 
 - `filter` - a filter object used to select the document to delete.
 - `options` - an options object passed to MongoDB's native
-  [`findOneAndDelete`](https://docs.mongodb.com/manual/reference/method/db.collection.findOneAndDelete/)
+  [`Collection.findOneAndDelete`](http://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#findOneAndDelete)
   method.
-- `callback` - the callback method using the signature `function (err, result)`
-  where:
-  - `err` - if the query failed, the error reason, otherwise `null`.
-  - `result` - if the query succeeded, a document as a class instance.
 
-### `findOneAndUpdate(filter, update, [options], callback)`
+### `async findOneAndReplace(filter, replacement, [options])`
 
-Finds one document matching a `filter`, updates it and returns it where:
+Finds one document matching a `filter`, deletes it and returns a model instance
+where:
+
+- `filter` - a filter object used to select the document to delete.
+- `replacement` - the document replacing the matching document.
+- `options` - an options object passed to MongoDB's native
+  [`Collection.findOneAndReplace`](http://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#findOneAndReplace)
+  method. Defaults to `{ returnOriginal: false }`.
+
+### `async findOneAndUpdate(filter, update, [options])`
+
+Finds one document matching a `filter`, updates it and returns a model instance
+where:
 
 - `filter` - a filter object used to select the document to update.
 - `update` - an object containing the fields/values to be updated.
 - `options` - an options object passed to MongoDB's native
-  [`findOneAndUpdate`](https://docs.mongodb.com/manual/reference/method/db.collection.findOneAndUpdate/)
+  [`Collection.findOneAndUpdate`](http://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#findOneAndUpdate)
   method. Defaults to `{ returnOriginal: false }`.
-- `callback` - the callback method using the signature `function (err, result)`
-  where:
-  - `err` - if the query failed, the error reason, otherwise `null`.
-  - `result` - if the command succeeded, a document as a class instance.
 
-### `insertMany(docs, [options], callback)`
+### `async insertMany(docs, [options])`
 
-Inserts multiple documents and returns them where:
+Inserts multiple documents and returns and array of model instances where:
 
 - `docs` - an array of document objects to insert.
 - `options` - an options object passed to MongoDB's native
-  [`insertMany`](https://docs.mongodb.com/manual/reference/method/db.collection.insertMany/)
+  [`Collection.insertMany`](http://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#insertMany)
   method.
-- `callback` - the callback method using the signature `function (err,
-  results)` where:
-  - `err` - if the query failed, the error reason, otherwise `null`.
-  - `results` - if the command succeeded, an array of documents as a class
-    instances.
 
-### `insertOne(doc, [options], callback)`
+### `async insertOne(doc, [options])`
 
-Inserts a document and returns the new document where:
+Inserts a document and returns a model instance where:
 
 - `doc` - a document object to insert.
 - `options` - an options object passed to MongoDB's native
-  [`insertOne`](https://docs.mongodb.com/manual/reference/method/db.collection.insertOne/)
+  [`Collection.insertOne`](http://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#insertOne)
   method.
-- `callback` - the callback method using the signature `function (err,
-  results)` where:
-  - `err` - if the query failed, the error reason, otherwise `null`.
-  - `results` - if the command succeeded, an array of documents as a class
-    instances.
 
-### `pagedFind(filter, fields, sort, limit, page, callback)`
+### `async pagedFind(filter, limit, page, [options])`
 
-Finds documents with paginated results where:
+Finds documents and returns the results where:
 
 - `filter` - a filter object used to select the documents.
-- `fields` - indicates which fields should be included in the response (default
-  is all). Can be a string with space separated field names.
-- `sort` - indicates how to sort documents. Can be a string with space
-  separated fields. Fields may be prefixed with `-` to indicate decending sort
-  order.
 - `limit` - a number indicating how many results should be returned.
 - `page` - a number indicating the current page.
-- `callback` - is the callback method using the signature `function (err,
-  results)` where:
-  - `err` - if the query failed, the error reason, otherwise null.
-  - `results` - the results object where:
-    - `data` - an array of documents from the query as class instances.
-    - `pages` - an object where:
-      - `current` - a number indicating the current page.
-      - `prev` - a number indicating the previous page.
-      - `hasPrev` - a boolean indicating if there is a previous page.
-      - `next` - a number indicating the next page.
-      - `hasNext` - a boolean indicating if there is a next page.
-      - `total` - a number indicating the total number of pages.
-    - `items` - an object where:
-      - `limit` - a number indicating the how many results should be returned.
-      - `begin` - a number indicating what item number the results begin with.
-      - `end` - a number indicating what item number the results end with.
-      - `total` - a number indicating the total number of matching results.
 
-### `replaceOne(filter, doc, [options], callback)`
+The returned value is an object where:
 
-Replaces a document and returns the count of modified documents where:
+- `data` - an array of model instances.
+- `pages` - an object where:
+  - `current` - a number indicating the current page.
+  - `prev` - a number indicating the previous page.
+  - `hasPrev` - a boolean indicating if there is a previous page.
+  - `next` - a number indicating the next page.
+  - `hasNext` - a boolean indicating if there is a next page.
+  - `total` - a number indicating the total number of pages.
+- `items` - an object where:
+  - `limit` - a number indicating the how many results should be returned.
+  - `begin` - a number indicating what item number the results begin with.
+  - `end` - a number indicating what item number the results end with.
+  - `total` - a number indicating the total number of matching results.
+
+### `async replaceOne(filter, doc, [options])`
+
+Replaces a document and returns a
+[`Collection.updateWriteOpResult`](http://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#~updateWriteOpResult)
+where:
 
 - `filter` - a filter object used to select the document to replace.
 - `doc` - the document that replaces the matching document.
 - `options` - an options object passed to MongoDB's native
-  [`replaceOne`](https://docs.mongodb.com/manual/reference/method/db.collection.replaceOne/)
+  [`Collection.replaceOne`](http://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#replaceOne)
   method.
-- `callback` - the callback method using the signature `function (err, count,
-  result)` where:
-  - `err` - if the query failed, the error reason, otherwise `null`.
-  - `count` - if the query succeeded, a number indicating how many documents
-    were modified.
-  - `result` - if the query succeeded, the raw result document returned by
-    MongoDB's native driver.
 
 ### `sortAdapter(sorts)`
 
@@ -431,90 +349,102 @@ where:
 Returns a MongoDB friendly sort object.
 
 ```js
-Kitten.sortAdapter('name -email');
+Customer.sortAdapter('name -email');
 
 // { name: 1, email: -1 }
 ```
 
-### `updateMany(filter, update, [options], callback)`
+### `async updateMany(filter, update, [options])`
 
-Updates multiple documents and returns the count of modified documents where:
+Updates multiple documents and returns a
+[`Collection.updateWriteOpResult`](http://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#~updateWriteOpResult)
+where:
 
 - `filter` - a filter object used to select the documents to update.
 - `update` - the update operations object.
 - `options` - an options object passed to MongoDB's native
-  [`updateMany`](https://docs.mongodb.com/manual/reference/method/db.collection.updateMany/)
+  [`Collection.updateMany`](http://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#updateMany)
   method.
-- `callback` - the callback method using the signature `function (err, count,
-  result)` where:
-  - `err` - if the query failed, the error reason, otherwise `null`.
-  - `count` - if the command succeeded, a number indicating how many documents
-    were modified.
-  - `result` - if the query succeeded, the raw result document returned by
-    MongoDB's native driver.
 
-### `updateOne(filter, update, [options], callback)`
+### `async updateOne(filter, update, [options])`
 
-Updates a document and returns the count of modified documents where:
+Updates a document and returns a
+[`Collection.updateWriteOpResult`](http://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#~updateWriteOpResult)
+where:
 
 - `filter` - a filter object used to select the document to update.
 - `update` - the update operations object.
 - `options` - an options object passed to MongoDB's native
-  [`updateOne`](https://docs.mongodb.com/manual/reference/method/db.collection.updateOne/)
+  [`Collection.updateOne`](http://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#updateOne)
   method.
-- `callback` - the callback method using the signature `function (err, count,
-  result)` where:
-  - `err` - if the query failed, the error reason, otherwise `null`.
-  - `count` - if the command succeeded, a number indicating how many documents
-    were modified.
-  - `result` - if the query succeeded, the raw result document returned by
-    MongoDB's native driver.
 
-### `validate(callback)`
+### `validate()`
 
-Uses `joi` validation using the static `schema` object property of a model
-class to validate the instance data of a model where:
-
-- `callback` - is the callback method using the signature `function (err,
-  value)` where:
-  - `err` - if validation failed, the error reason, otherwise null.
-  - `value` - the validated value with any type conversions and other modifiers
-    applied.
+Uses `joi` validation internally with the static `schema` property of the model
+to validate the instance data and returns the validated value where:
 
 ```js
-const cc = new Kitten({
-    name: 'Captain Cute'
+const stephen = new Customer({
+    name: 'Stephen Colbert'
 });
 
-cc.validate((err, value) => {
-
-    // handle results
-});
+const result = stephen.validate();
 ```
 
 See: https://github.com/hapijs/joi/blob/master/API.md#validatevalue-schema-options-callback
 
-### `validate(input, callback)`
+### `validate(input)`
 
-Uses `joi` validation using the static `schema` object property of a model
-class to validate `input` where:
+Uses `joi` validation internally with the static `schema` property of the model
+to validate the `input` data and returns the validated value where:
 
 - `input` - is the object to validate.
-- `callback` - is the callback method using the signature `function (err,
-  value)` where:
-  - `err` - if validation failed, the error reason, otherwise null.
-  - `value` - the validated value with any type conversions and other modifiers
-    applied.
 
 ```js
 const data = {
-    name: 'Captain Cute'
+    name: 'Stephen Colbert'
 };
 
-Kitten.validate(data, (err, value) => {
-
-    // handle results
-});
+const result = Customer.validate(data);
 ```
 
 See: https://github.com/hapijs/joi/blob/master/API.md#validatevalue-schema-options-callback
+
+### `with(name)`
+
+For use with multiple named connections (See: [`connect(connection, [options],
+[name])`](#connectconnection-options-name)).
+
+Returns an object containing subset of the model's methods bound to the named
+connection.
+
+Available methods include:
+ - `aggregate`
+ - `collection`
+ - `count`
+ - `createIndexes`
+ - `deleteMany`
+ - `deleteOne`
+ - `distinct`
+ - `find`
+ - `findById`
+ - `findByIdAndDelete`
+ - `findByIdAndUpdate`
+ - `findOne`
+ - `findOneAndDelete`
+ - `findOneAndReplace`
+ - `findOneAndUpdate`
+ - `insertMany`
+ - `insertOne`
+ - `pagedFind`
+ - `replaceOne`
+ - `updateMany`
+ - `updateOne`
+
+```js
+await MongoModels.connect(config.connection, config.options, 'alt');
+
+// ...
+
+const count = await Customer.with('alt').count({});
+```

--- a/API.md
+++ b/API.md
@@ -5,6 +5,7 @@
 - [Properties](#properties)
   - [`_idClass`](#_idclass)
   - [`collectionName`](#collectionname)
+  - [`indexes`](#indexes)
   - [`ObjectID`](#objectid)
   - [`schema`](#schema)
 - [Methods](#methods)
@@ -13,7 +14,7 @@
   - [`collection()`](#collection)
   - [`async connect(connection, [options], [name])`](#async-connectconnection-options-name)
   - [`async count(query, [options])`](#async-countquery-options)
-  - [`async createIndexes(indexSpecs)`](#async-createindexesindexspecs)
+  - [`async createIndexes(indexSpecs, [options])`](#async-createindexesindexspecs-options)
   - [`async deleteMany(filter, [options])`](#async-deletemanyfilter-options)
   - [`async deleteOne(filter, [options])`](#async-deleteonefilter-options)
   - [`disconnect([name])`](#disconnectname)
@@ -71,6 +72,27 @@ The name of the collection in MongoDB.
 
 ```js
 Customer.collectionName = 'customers';
+```
+
+### `indexes`
+
+An array of index specifications for this model. [See the index
+specification](http://docs.mongodb.org/manual/reference/command/createIndexes/).
+
+```js
+Customer.indexes = [
+    { key: { name: 1 } },
+    { key: { email: -1 } }
+];
+```
+
+Note: These are just the definitions, the [`async createIndexes(indexSpecs,
+[options])`](#async-createindexesindexspecs-options) method doesn't
+automatically use this property. You could pass this property to that method
+though:
+
+```js
+const result = await Customer.createIndexes(Customer.indexes);
 ```
 
 ### `ObjectID`
@@ -139,13 +161,16 @@ Returns the number of documents matching a `query` where:
   [`Collection.count`](https://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#count)
   method.
 
-### `async createIndexes(indexSpecs)`
+### `async createIndexes(indexSpecs, [options])`
 
 Creates multiple indexes in the collection and returns the result where:
 
 - `indexSpecs` - an array of objects containing index specifications to be
   created. [See the index
-  specification](http://docs.mongodb.org/manual/reference/command/createIndexes/)
+  specification](http://docs.mongodb.org/manual/reference/command/createIndexes/).
+- `options` - an optional object passed to the native
+  [`Collection.createIndexes`](https://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#createIndexes)
+  method.
 
 Indexes are defined as a static property on your models like:
 

--- a/API.md
+++ b/API.md
@@ -416,7 +416,7 @@ See: https://github.com/hapijs/joi/blob/master/API.md#validatevalue-schema-optio
 ### `with(name)`
 
 For use with multiple named connections (See: [`connect(connection, [options],
-[name])`](#connectconnection-options-name)).
+[name])`](#async-connectconnection-options-name)).
 
 Returns an object containing subset of the model's methods bound to the named
 connection.

--- a/API.md
+++ b/API.md
@@ -106,7 +106,7 @@ Constructs a new instance of your class using the data provided where:
 Execute an aggregation framework pipeline against the collection.
 
 - `pipeline` - an array containing all the aggregation framework commands.
-- `options` - an optional options object passed to MongoDB's native
+- `options` - an optional object passed to MongoDB's native
   [`Collection.aggregate`](https://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#aggregate)
   method.
 
@@ -135,7 +135,7 @@ where:
 Returns the number of documents matching a `query` where:
 
 - `query` - a filter object used to select the documents to count.
-- `options` - an options object passed to the native
+- `options` - an optional object passed to the native
   [`Collection.count`](https://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#count)
   method.
 
@@ -163,7 +163,7 @@ Deletes multiple documents and returns the
 where:
 
 - `filter` - a filter object used to select the documents to delete.
-- `options` - an options object passed to MongoDB's native
+- `options` - an optional object passed to MongoDB's native
   [`Collection.deleteMany`](https://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#deleteMany)
   method.
 
@@ -174,7 +174,7 @@ Deletes a document and returns the
 where:
 
 - `filter` - a filter object used to select the document to delete.
-- `options` - an options object passed to MongoDB's native
+- `options` - an optional object passed to MongoDB's native
   [`Collection.deleteOne`](https://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#deleteOne)
   method.
 
@@ -211,7 +211,7 @@ Customer.fieldsAdapter('name -email');
 Finds documents and returns an array of model instances where:
 
 - `query` - a query object used to select the documents.
-- `options` - an options object passed to MongoDB's native
+- `options` - an optional object passed to MongoDB's native
   [`Collection.find`](https://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#find)
   method.
 
@@ -221,7 +221,7 @@ Finds a document by `_id` and returns a model instance where:
 
 - `id` - a string value of the `_id` to find. The `id` will be casted to the
   type of `_idClass`.
-- `options` - an options object passed to MongoDB's native
+- `options` - an optional object passed to MongoDB's native
   [`Collection.findOne`](https://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#findOne)
   method.
 
@@ -239,7 +239,7 @@ Finds a document by `_id`, updates it and returns a model instance where:
 - `id` - a string value of the `_id` to find. The `id` will be casted to the
   type of `_idClass`.
 - `update` - an object containing the fields/values to be updated.
-- `options` - an optional options object passed to MongoDB's native
+- `options` - an optional object passed to MongoDB's native
   [`Collection.findOneAndUpdate`](https://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#findOneAndUpdate)
   method. Defaults to `{ returnOriginal: false }`.
 
@@ -248,7 +248,7 @@ Finds a document by `_id`, updates it and returns a model instance where:
 Finds one document matching the `query` and returns a model intance where:
 
 - `query` - a filter object used to select the document.
-- `options` - an options object passed to MongoDB's native
+- `options` - an optional object passed to MongoDB's native
   [`Collection.findOne`](https://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#findOne)
   method.
 
@@ -258,7 +258,7 @@ Finds one document matching a `filter`, deletes it and returns a model instance
 where:
 
 - `filter` - a filter object used to select the document to delete.
-- `options` - an options object passed to MongoDB's native
+- `options` - an optional object passed to MongoDB's native
   [`Collection.findOneAndDelete`](https://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#findOneAndDelete)
   method.
 
@@ -269,7 +269,7 @@ where:
 
 - `filter` - a filter object used to select the document to delete.
 - `replacement` - the document replacing the matching document.
-- `options` - an options object passed to MongoDB's native
+- `options` - an optional object passed to MongoDB's native
   [`Collection.findOneAndReplace`](https://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#findOneAndReplace)
   method. Defaults to `{ returnOriginal: false }`.
 
@@ -280,7 +280,7 @@ where:
 
 - `filter` - a filter object used to select the document to update.
 - `update` - an object containing the fields/values to be updated.
-- `options` - an options object passed to MongoDB's native
+- `options` - an optional object passed to MongoDB's native
   [`Collection.findOneAndUpdate`](https://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#findOneAndUpdate)
   method. Defaults to `{ returnOriginal: false }`.
 
@@ -289,7 +289,7 @@ where:
 Inserts multiple documents and returns and array of model instances where:
 
 - `docs` - an array of document objects to insert.
-- `options` - an options object passed to MongoDB's native
+- `options` - an optional object passed to MongoDB's native
   [`Collection.insertMany`](https://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#insertMany)
   method.
 
@@ -298,7 +298,7 @@ Inserts multiple documents and returns and array of model instances where:
 Inserts a document and returns a model instance where:
 
 - `doc` - a document object to insert.
-- `options` - an options object passed to MongoDB's native
+- `options` - an optional object passed to MongoDB's native
   [`Collection.insertOne`](https://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#insertOne)
   method.
 
@@ -309,7 +309,7 @@ Finds documents and returns the results where:
 - `filter` - a filter object used to select the documents.
 - `limit` - a number indicating how many results should be returned.
 - `page` - a number indicating the current page.
-- `options` - an options object passed to MongoDB's native
+- `options` - an optional object passed to MongoDB's native
   [`Collection.find`](https://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#find)
   method.
 
@@ -337,7 +337,7 @@ where:
 
 - `filter` - a filter object used to select the document to replace.
 - `doc` - the document that replaces the matching document.
-- `options` - an options object passed to MongoDB's native
+- `options` - an optional object passed to MongoDB's native
   [`Collection.replaceOne`](https://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#replaceOne)
   method.
 
@@ -365,7 +365,7 @@ where:
 
 - `filter` - a filter object used to select the documents to update.
 - `update` - the update operations object.
-- `options` - an options object passed to MongoDB's native
+- `options` - an optional object passed to MongoDB's native
   [`Collection.updateMany`](https://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#updateMany)
   method.
 
@@ -377,7 +377,7 @@ where:
 
 - `filter` - a filter object used to select the document to update.
 - `update` - the update operations object.
-- `options` - an options object passed to MongoDB's native
+- `options` - an optional object passed to MongoDB's native
   [`Collection.updateOne`](https://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#updateOne)
   method.
 

--- a/API.md
+++ b/API.md
@@ -45,7 +45,7 @@
 ### `_idClass`
 
 The type used to cast `_id` properties. Defaults to
-[`MongoDB.ObjectID`](http://mongodb.github.io/node-mongodb-native/3.0/api/ObjectID.html).
+[`MongoDB.ObjectID`](https://mongodb.github.io/node-mongodb-native/3.0/api/ObjectID.html).
 
 If you wanted to use plain strings for your document `_id` properties you could:
 
@@ -76,7 +76,7 @@ Customer.collectionName = 'customers';
 ### `ObjectID`
 
 An alias to
-[`MongoDB.ObjectID`](http://mongodb.github.io/node-mongodb-native/3.0/api/ObjectID.html).
+[`MongoDB.ObjectID`](https://mongodb.github.io/node-mongodb-native/3.0/api/ObjectID.html).
 
 ### `schema`
 
@@ -107,18 +107,18 @@ Execute an aggregation framework pipeline against the collection.
 
 - `pipeline` - an array containing all the aggregation framework commands.
 - `options` - an optional options object passed to MongoDB's native
-  [`aggregate`](http://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#aggregate)
+  [`Collection.aggregate`](https://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#aggregate)
   method.
 
 ### `collection()`
 
 Returns the underlying
-[`MongoDB.Collection`](http://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html).
+[`MongoDB.Collection`](https://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html).
 
 ### `async connect(connection, [options], [name])`
 
 Connects to a MongoDB server and returns the
-[`MongoDB.Db`](http://mongodb.github.io/node-mongodb-native/3.0/api/Db.html)
+[`MongoDB.Db`](https://mongodb.github.io/node-mongodb-native/3.0/api/Db.html)
 where:
 
 - `connection` - an object where:
@@ -136,7 +136,7 @@ Returns the number of documents matching a `query` where:
 
 - `query` - a filter object used to select the documents to count.
 - `options` - an options object passed to the native
-  [`Collection.count`](http://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#count)
+  [`Collection.count`](https://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#count)
   method.
 
 ### `async createIndexes(indexSpecs)`
@@ -159,23 +159,23 @@ Customer.indexes = [
 ### `async deleteMany(filter, [options])`
 
 Deletes multiple documents and returns the
-[`Collection.deleteWriteOpResult`](http://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#~deleteWriteOpResult)
+[`Collection.deleteWriteOpResult`](https://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#~deleteWriteOpResult)
 where:
 
 - `filter` - a filter object used to select the documents to delete.
 - `options` - an options object passed to MongoDB's native
-  [`Collection.deleteMany`](http://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#deleteMany)
+  [`Collection.deleteMany`](https://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#deleteMany)
   method.
 
 ### `async deleteOne(filter, [options])`
 
 Deletes a document and returns the
-[`Collection.deleteWriteOpResult`](http://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#~deleteWriteOpResult)
+[`Collection.deleteWriteOpResult`](https://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#~deleteWriteOpResult)
 where:
 
 - `filter` - a filter object used to select the document to delete.
 - `options` - an options object passed to MongoDB's native
-  [`Collection.deleteOne`](http://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#deleteOne)
+  [`Collection.deleteOne`](https://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#deleteOne)
   method.
 
 ### `disconnect([name])`
@@ -212,7 +212,7 @@ Finds documents and returns an array of model instances where:
 
 - `query` - a query object used to select the documents.
 - `options` - an options object passed to MongoDB's native
-  [`find`](http://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#find)
+  [`Collection.find`](https://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#find)
   method.
 
 ### `async findById(id, [options])`
@@ -222,7 +222,7 @@ Finds a document by `_id` and returns a model instance where:
 - `id` - a string value of the `_id` to find. The `id` will be casted to the
   type of `_idClass`.
 - `options` - an options object passed to MongoDB's native
-  [`Collection.findOne`](http://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#findOne)
+  [`Collection.findOne`](https://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#findOne)
   method.
 
 ### `async findByIdAndDelete(id)`
@@ -240,7 +240,7 @@ Finds a document by `_id`, updates it and returns a model instance where:
   type of `_idClass`.
 - `update` - an object containing the fields/values to be updated.
 - `options` - an optional options object passed to MongoDB's native
-  [`Collection.findOneAndUpdate`](http://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#findOneAndUpdate)
+  [`Collection.findOneAndUpdate`](https://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#findOneAndUpdate)
   method. Defaults to `{ returnOriginal: false }`.
 
 ### `async findOne(query, [options])`
@@ -249,7 +249,7 @@ Finds one document matching the `query` and returns a model intance where:
 
 - `query` - a filter object used to select the document.
 - `options` - an options object passed to MongoDB's native
-  [`Collection.findOne`](http://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#findOne)
+  [`Collection.findOne`](https://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#findOne)
   method.
 
 ### `async findOneAndDelete(filter, [options])`
@@ -259,7 +259,7 @@ where:
 
 - `filter` - a filter object used to select the document to delete.
 - `options` - an options object passed to MongoDB's native
-  [`Collection.findOneAndDelete`](http://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#findOneAndDelete)
+  [`Collection.findOneAndDelete`](https://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#findOneAndDelete)
   method.
 
 ### `async findOneAndReplace(filter, replacement, [options])`
@@ -270,7 +270,7 @@ where:
 - `filter` - a filter object used to select the document to delete.
 - `replacement` - the document replacing the matching document.
 - `options` - an options object passed to MongoDB's native
-  [`Collection.findOneAndReplace`](http://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#findOneAndReplace)
+  [`Collection.findOneAndReplace`](https://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#findOneAndReplace)
   method. Defaults to `{ returnOriginal: false }`.
 
 ### `async findOneAndUpdate(filter, update, [options])`
@@ -281,7 +281,7 @@ where:
 - `filter` - a filter object used to select the document to update.
 - `update` - an object containing the fields/values to be updated.
 - `options` - an options object passed to MongoDB's native
-  [`Collection.findOneAndUpdate`](http://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#findOneAndUpdate)
+  [`Collection.findOneAndUpdate`](https://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#findOneAndUpdate)
   method. Defaults to `{ returnOriginal: false }`.
 
 ### `async insertMany(docs, [options])`
@@ -290,7 +290,7 @@ Inserts multiple documents and returns and array of model instances where:
 
 - `docs` - an array of document objects to insert.
 - `options` - an options object passed to MongoDB's native
-  [`Collection.insertMany`](http://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#insertMany)
+  [`Collection.insertMany`](https://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#insertMany)
   method.
 
 ### `async insertOne(doc, [options])`
@@ -299,7 +299,7 @@ Inserts a document and returns a model instance where:
 
 - `doc` - a document object to insert.
 - `options` - an options object passed to MongoDB's native
-  [`Collection.insertOne`](http://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#insertOne)
+  [`Collection.insertOne`](https://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#insertOne)
   method.
 
 ### `async pagedFind(filter, limit, page, [options])`
@@ -329,13 +329,13 @@ The returned value is an object where:
 ### `async replaceOne(filter, doc, [options])`
 
 Replaces a document and returns a
-[`Collection.updateWriteOpResult`](http://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#~updateWriteOpResult)
+[`Collection.updateWriteOpResult`](https://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#~updateWriteOpResult)
 where:
 
 - `filter` - a filter object used to select the document to replace.
 - `doc` - the document that replaces the matching document.
 - `options` - an options object passed to MongoDB's native
-  [`Collection.replaceOne`](http://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#replaceOne)
+  [`Collection.replaceOne`](https://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#replaceOne)
   method.
 
 ### `sortAdapter(sorts)`
@@ -357,25 +357,25 @@ Customer.sortAdapter('name -email');
 ### `async updateMany(filter, update, [options])`
 
 Updates multiple documents and returns a
-[`Collection.updateWriteOpResult`](http://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#~updateWriteOpResult)
+[`Collection.updateWriteOpResult`](https://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#~updateWriteOpResult)
 where:
 
 - `filter` - a filter object used to select the documents to update.
 - `update` - the update operations object.
 - `options` - an options object passed to MongoDB's native
-  [`Collection.updateMany`](http://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#updateMany)
+  [`Collection.updateMany`](https://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#updateMany)
   method.
 
 ### `async updateOne(filter, update, [options])`
 
 Updates a document and returns a
-[`Collection.updateWriteOpResult`](http://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#~updateWriteOpResult)
+[`Collection.updateWriteOpResult`](https://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#~updateWriteOpResult)
 where:
 
 - `filter` - a filter object used to select the document to update.
 - `update` - the update operations object.
 - `options` - an options object passed to MongoDB's native
-  [`Collection.updateOne`](http://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#updateOne)
+  [`Collection.updateOne`](https://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#updateOne)
   method.
 
 ### `validate()`

--- a/README.md
+++ b/README.md
@@ -35,25 +35,24 @@ $ npm install mongo-models
 ### Creating models
 
 You extend the `MongoModels` class to create new model classes that map to
-MongoDB collections. The base class also acts as a singleton so models share
-one connection per process.
+MongoDB collections.
 
 Let's create a `Customer` model.
 
 ```js
 const Joi = require('joi');
-const MongoModels = require('mongo-models');
+const MongoModels = require('../');
 
 class Customer extends MongoModels {
-    static create(name, email, phone, callback) {
+    static async create(name, email, phone) {
 
-      const document = {
+      const document = new Customer({
           name,
           email,
           phone
-      };
+      });
 
-      this.insertOne(document, callback);
+      return this.insertOne(document);
     }
 
     speak() {
@@ -62,7 +61,7 @@ class Customer extends MongoModels {
     }
 }
 
-Customer.collection = 'customers'; // the mongodb collection name
+Customer.collectionName = 'customers'; // the mongodb collection name
 
 Customer.schema = Joi.object().keys({
     name: Joi.string().required(),
@@ -73,67 +72,25 @@ Customer.schema = Joi.object().keys({
 module.exports = Customer;
 ```
 
-### Example
 
-```js
-const Customer = require('./customer');
-const Express = require('express');
-const MongoModels = require('mongo-models');
+## Example
 
-const app = Express();
+Before you can run the example, you need to clone this repo and install the
+dependencies.
 
-MongoModels.connect(process.env.MONGODB_URI, {}, (err, db) => {
+```bash
+$ git clone https://github.com/jedireza/mongo-models.git
+$ cd mongo-models
+$ npm install
+```
 
-    if (err) {
-        // TODO: throw error or try reconnecting
-        return;
-    }
+The example is a simple Express API that based on the Customer model above.
+[View the code.][example]
 
-    // optionally, we can keep a reference to db if we want
-    // access to the db connection outside of our models
-    app.db = db;
+[example]: https://github.com/jedireza/mongo-models/tree/master/example
 
-    console.log('Models are now connected to mongodb.');
-});
-
-app.post('/customers', (req, res) => {
-
-    const name = req.body.name;
-    const email = req.body.email;
-    const phone = req.body.phone;
-
-    Customer.create(name, email, phone, (err, customers) => {
-
-        if (err) {
-            res.status(500).json({ error: 'something blew up' });
-            return;
-        }
-
-        res.json(customers[0]);
-    });
-});
-
-app.get('/customers', (req, res) => {
-
-    const filter = {
-        name: req.query.name
-    };
-
-    Customer.find(filter, (err, customers) => {
-
-        if (err) {
-            res.status(500).json({ error: 'something blew up' });
-            return;
-        }
-
-        res.json(customers);
-    });
-});
-
-app.server.listen(process.env.PORT, () => {
-
-    console.log(`Server is running on port ${process.env.PORT}`);
-});
+```bash
+$ npm run example
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ We're also big fans of the object schema validation library
 data schema.
 
 
+## API reference
+
+See the [API reference](https://github.com/jedireza/mongo-models/blob/master/API.md).
+
+
 ## Install
 
 ```bash
@@ -163,11 +168,6 @@ The example is a simple Express API that based on the Customer model above.
 ```bash
 $ npm run example
 ```
-
-
-## API
-
-See the [API Reference](https://github.com/jedireza/mongo-models/blob/master/API.md).
 
 
 ## Have a question?

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ $ npm run example
 
 ## API
 
-See the [API Reference](https://github.com/jedireza/mongo-models/blob/v1.4.0/API.md).
+See the [API Reference](https://github.com/jedireza/mongo-models/blob/master/API.md).
 
 
 ## Have a question?

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mongo-models
 
-Map JavaScript classes to MongoDB collections.
+JavaScript class interfaces to MongoDB collections.
 
 [![Build Status](https://img.shields.io/travis/jedireza/mongo-models.svg)](https://travis-ci.org/jedireza/mongo-models)
 [![Dependency Status](https://img.shields.io/david/jedireza/mongo-models.svg)](https://david-dm.org/jedireza/mongo-models)

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ $ npm run example
 
 ## API
 
-See the [API reference](https://github.com/jedireza/mongo-models/blob/master/API.md).
+See the [API Reference](https://github.com/jedireza/mongo-models/blob/v1.4.0/API.md).
 
 
 ## Have a question?

--- a/example/customer.js
+++ b/example/customer.js
@@ -12,15 +12,15 @@ const schema = Joi.object().keys({
 
 
 class Customer extends MongoModels {
-    static async create(name, email, phone) {
+    static create(name, email, phone) {
 
-      const document = new Customer({
-          name,
-          email,
-          phone
-      });
+        const document = new Customer({
+            name,
+            email,
+            phone
+        });
 
-      return this.insertOne(document);
+        return this.insertOne(document);
     }
 
     speak() {

--- a/example/customer.js
+++ b/example/customer.js
@@ -1,0 +1,37 @@
+'use strict';
+const Joi = require('joi');
+const MongoModels = require('../');
+
+
+const schema = Joi.object().keys({
+    _id: Joi.object(),
+    name: Joi.string().required(),
+    email: Joi.string().email(),
+    phone: Joi.string()
+});
+
+
+class Customer extends MongoModels {
+    static async create(name, email, phone) {
+
+      const document = new Customer({
+          name,
+          email,
+          phone
+      });
+
+      return this.insertOne(document);
+    }
+
+    speak() {
+
+        console.log(`${this.name}: call me at ${this.phone}.`);
+    }
+}
+
+
+Customer.collectionName = 'customers'; // the mongodb collection name
+Customer.schema = schema;
+
+
+module.exports = Customer;

--- a/example/server.js
+++ b/example/server.js
@@ -1,0 +1,69 @@
+'use strict';
+const BodyParser = require('body-parser')
+const Customer = require('./customer');
+const Express = require('express');
+const MongoModels = require('../');
+
+
+const app = Express();
+const connection = {
+    uri: process.env.MONGODB_URI,
+    db: process.env.MONGODB_NAME
+};
+
+app.use(BodyParser.json());
+
+app.post('/customers', async (req, res) => {
+
+    const name = req.body.name;
+    const email = req.body.email;
+    const phone = req.body.phone;
+
+    let customers;
+
+    try {
+        customers = await Customer.create(name, email, phone);
+    }
+    catch (err) {
+        res.status(500).json({ error: 'something blew up' });
+        return;
+    }
+
+    res.json(customers[0]);
+});
+
+app.get('/customers', async (req, res) => {
+
+    const name = req.query.name;
+    const filter = {};
+
+    if (name) {
+        filter.name = name;
+    }
+
+    let customers;
+
+    try {
+        customers = await Customer.find(filter);
+    }
+    catch (err) {
+        res.status(500).json({ error: 'something blew up' });
+        return;
+    }
+
+    res.json(customers);
+});
+
+
+const main = async function () {
+
+    await MongoModels.connect(connection, {});
+
+    console.log('Models are now connected.');
+
+    await app.listen(process.env.PORT);
+
+    console.log(`Server is running on port ${process.env.PORT}`);
+};
+
+main();

--- a/example/server.js
+++ b/example/server.js
@@ -1,5 +1,5 @@
 'use strict';
-const BodyParser = require('body-parser')
+const BodyParser = require('body-parser');
 const Customer = require('./customer');
 const Express = require('express');
 const MongoModels = require('../');
@@ -18,7 +18,6 @@ app.post('/customers', async (req, res) => {
     const name = req.body.name;
     const email = req.body.email;
     const phone = req.body.phone;
-
     let customers;
 
     try {

--- a/index.js
+++ b/index.js
@@ -29,9 +29,9 @@ const dbFromArgs = function (args) {
 
 
 class MongoModels {
-    constructor(attrs) {
+    constructor(data) {
 
-        const result = this.constructor.validate(attrs);
+        const result = this.constructor.validate(data);
 
         if (result.error) {
             throw result.error;

--- a/index.js
+++ b/index.js
@@ -60,14 +60,14 @@ class MongoModels {
     }
 
 
-    static async connect(connection, options = {}, connectionName = 'default') {
+    static async connect(connection, options = {}, name = 'default') {
 
         const client = await Mongodb.MongoClient.connect(connection.uri, options);
 
-        MongoModels.clients[connectionName] = client;
-        MongoModels.dbs[connectionName] = client.db(connection.db);
+        MongoModels.clients[name] = client;
+        MongoModels.dbs[name] = client.db(connection.db);
 
-        return MongoModels.dbs[connectionName];
+        return MongoModels.dbs[name];
     }
 
 

--- a/index.js
+++ b/index.js
@@ -319,14 +319,10 @@ class MongoModels {
 
         const args = argsFromArguments(arguments);
         const db = dbFromArgs(args);
-        const page = args.pop();
-        const limit = args.pop();
-        let sort = args.pop();
-        let fields = args.pop();
-        const filter = args.pop();
-
-        fields = this.fieldsAdapter(fields);
-        sort = this.sortAdapter(sort);
+        const filter = args.shift();
+        const page = args.shift();
+        const limit = args.shift();
+        const options = args.pop() || {};
 
         const output = {
             data: undefined,
@@ -345,14 +341,13 @@ class MongoModels {
                 total: 0
             }
         };
-        const findOptions = {
+        const findOptions = Object.assign({}, options, {
             limit,
-            skip: (page - 1) * limit,
-            sort
-        };
+            skip: (page - 1) * limit
+        });
         const [count, results] = await Promise.all([
             this.count(db, filter),
-            this.find(db, filter, fields, findOptions)
+            this.find(db, filter, findOptions)
         ]);
 
         output.data = results;
@@ -531,6 +526,7 @@ class MongoModels {
                 findOneAndUpdate: this.findOneAndUpdate.bind(this, db),
                 insertMany: this.insertMany.bind(this, db),
                 insertOne: this.insertOne.bind(this, db),
+                pagedFind: this.pagedFind.bind(this, db),
                 replaceOne: this.replaceOne.bind(this, db),
                 updateMany: this.updateMany.bind(this, db),
                 updateOne: this.updateOne.bind(this, db)

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,16 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "accepts": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
+      "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
+      "dev": true,
+      "requires": {
+        "mime-types": "2.1.17",
+        "negotiator": "0.6.1"
+      }
+    },
     "acorn": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.3.0.tgz",
@@ -89,6 +99,12 @@
         "sprintf-js": "1.0.3"
       }
     },
+    "array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
+      "dev": true
+    },
     "array-union": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
@@ -163,6 +179,35 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
+    "body-parser": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
+      "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+      "dev": true,
+      "requires": {
+        "bytes": "3.0.0",
+        "content-type": "1.0.4",
+        "debug": "2.6.9",
+        "depd": "1.1.2",
+        "http-errors": "1.6.2",
+        "iconv-lite": "0.4.19",
+        "on-finished": "2.3.0",
+        "qs": "6.5.1",
+        "raw-body": "2.3.2",
+        "type-is": "1.6.15"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "boom": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-7.1.1.tgz",
@@ -197,6 +242,12 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.4.tgz",
       "integrity": "sha1-k8ENOeqltYQVy8QFLz5T5WKwtyw=",
+      "dev": true
+    },
+    "bytes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
       "dev": true
     },
     "caller-path": {
@@ -349,6 +400,30 @@
         "typedarray": "0.0.6"
       }
     },
+    "content-disposition": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
+      "dev": true
+    },
+    "content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+      "dev": true
+    },
+    "cookie": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
+      "dev": true
+    },
+    "cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
+      "dev": true
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -403,6 +478,18 @@
         "rimraf": "2.6.2"
       }
     },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+      "dev": true
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+      "dev": true
+    },
     "diff": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
@@ -417,6 +504,24 @@
       "requires": {
         "esutils": "2.0.2"
       }
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+      "dev": true
+    },
+    "encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+      "dev": true
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+      "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -551,6 +656,61 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
+    "etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+      "dev": true
+    },
+    "express": {
+      "version": "4.16.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.16.2.tgz",
+      "integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
+      "dev": true,
+      "requires": {
+        "accepts": "1.3.4",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.18.2",
+        "content-disposition": "0.5.2",
+        "content-type": "1.0.4",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "1.1.2",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
+        "finalhandler": "1.1.0",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "1.1.2",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "2.0.2",
+        "qs": "6.5.1",
+        "range-parser": "1.2.0",
+        "safe-buffer": "5.1.1",
+        "send": "0.16.1",
+        "serve-static": "1.13.1",
+        "setprototypeof": "1.1.0",
+        "statuses": "1.3.1",
+        "type-is": "1.6.15",
+        "utils-merge": "1.0.1",
+        "vary": "1.1.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "external-editor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
@@ -599,6 +759,32 @@
         "object-assign": "4.1.1"
       }
     },
+    "finalhandler": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
+      "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
+        "statuses": "1.3.1",
+        "unpipe": "1.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "find-rc": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/find-rc/-/find-rc-3.0.1.tgz",
@@ -616,6 +802,18 @@
         "graceful-fs": "4.1.11",
         "write": "0.2.1"
       }
+    },
+    "forwarded": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
+      "dev": true
+    },
+    "fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+      "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -736,6 +934,32 @@
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.2.tgz",
       "integrity": "sha512-NA10UYP9ufCtY2qYGkZktcQXwVyYK4zK0gkaFSB96xhtlo6V8tKXdQgx8eHolQTRemaW0uLn8BhjhwqrOU+QLQ=="
     },
+    "http-errors": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+      "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+      "dev": true,
+      "requires": {
+        "depd": "1.1.1",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.0.3",
+        "statuses": "1.3.1"
+      },
+      "dependencies": {
+        "depd": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+          "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
+          "dev": true
+        },
+        "setprototypeof": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+          "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
+          "dev": true
+        }
+      }
+    },
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
@@ -791,6 +1015,12 @@
         "strip-ansi": "4.0.0",
         "through": "2.3.8"
       }
+    },
+    "ipaddr.js": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.5.2.tgz",
+      "integrity": "sha1-1LUFvemUaYfM8PxY2QEP+WB+P6A=",
+      "dev": true
     },
     "is-buffer": {
       "version": "1.1.6",
@@ -992,6 +1222,45 @@
         "yallist": "2.1.2"
       }
     },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+      "dev": true
+    },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+      "dev": true
+    },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+      "dev": true
+    },
+    "mime": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+      "dev": true
+    },
+    "mime-db": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
+      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE=",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.17",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+      "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+      "dev": true,
+      "requires": {
+        "mime-db": "1.30.0"
+      }
+    },
     "mimic-fn": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
@@ -1059,6 +1328,12 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "negotiator": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
+      "dev": true
+    },
     "no-arrowception": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/no-arrowception/-/no-arrowception-1.0.0.tgz",
@@ -1070,6 +1345,15 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "dev": true,
+      "requires": {
+        "ee-first": "1.1.1"
+      }
     },
     "once": {
       "version": "1.4.0",
@@ -1127,6 +1411,12 @@
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
+    "parseurl": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
+      "dev": true
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -1137,6 +1427,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
       "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
+    "path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
       "dev": true
     },
     "pify": {
@@ -1184,6 +1480,16 @@
       "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
       "dev": true
     },
+    "proxy-addr": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.2.tgz",
+      "integrity": "sha1-ZXFQT0e7mI7IGAJT+F3X4UlSvew=",
+      "dev": true,
+      "requires": {
+        "forwarded": "0.1.2",
+        "ipaddr.js": "1.5.2"
+      }
+    },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
@@ -1194,6 +1500,30 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
       "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
+    },
+    "qs": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+      "dev": true
+    },
+    "range-parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
+      "dev": true
+    },
+    "raw-body": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
+      "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+      "dev": true,
+      "requires": {
+        "bytes": "3.0.0",
+        "http-errors": "1.6.2",
+        "iconv-lite": "0.4.19",
+        "unpipe": "1.0.0"
+      }
     },
     "readable-stream": {
       "version": "2.3.3",
@@ -1321,6 +1651,56 @@
       "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
       "dev": true
     },
+    "send": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.16.1.tgz",
+      "integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "depd": "1.1.2",
+        "destroy": "1.0.4",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "1.6.2",
+        "mime": "1.4.1",
+        "ms": "2.0.0",
+        "on-finished": "2.3.0",
+        "range-parser": "1.2.0",
+        "statuses": "1.3.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "serve-static": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.1.tgz",
+      "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
+      "dev": true,
+      "requires": {
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "parseurl": "1.3.2",
+        "send": "0.16.1"
+      }
+    },
+    "setprototypeof": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+      "dev": true
+    },
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -1370,6 +1750,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "statuses": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+      "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
       "dev": true
     },
     "string-width": {
@@ -1475,6 +1861,16 @@
         "prelude-ls": "1.1.2"
       }
     },
+    "type-is": {
+      "version": "1.6.15",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
+      "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
+      "dev": true,
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "2.1.17"
+      }
+    },
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
@@ -1509,10 +1905,28 @@
       "dev": true,
       "optional": true
     },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+      "dev": true
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+      "dev": true
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
       "dev": true
     },
     "which": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "acorn": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
-      "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.3.0.tgz",
+      "integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug==",
       "dev": true
     },
     "acorn-jsx": {
@@ -28,9 +28,9 @@
       }
     },
     "ajv": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
-      "integrity": "sha1-RBT/dKUIecII7l/cgm4ywwNUnto=",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "dev": true,
       "requires": {
         "co": "4.6.0",
@@ -111,13 +111,10 @@
       "dev": true
     },
     "async": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-      "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
-      "dev": true,
-      "requires": {
-        "lodash": "4.17.4"
-      }
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+      "dev": true
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -183,7 +180,7 @@
       "requires": {
         "boom": "7.1.1",
         "hoek": "5.0.2",
-        "joi": "13.0.2"
+        "joi": "13.1.1"
       }
     },
     "brace-expansion": {
@@ -200,12 +197,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.4.tgz",
       "integrity": "sha1-k8ENOeqltYQVy8QFLz5T5WKwtyw=",
-      "dev": true
-    },
-    "buffer-shims": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
       "dev": true
     },
     "caller-path": {
@@ -262,6 +253,12 @@
           }
         }
       }
+    },
+    "chardet": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+      "dev": true
     },
     "circular-json": {
       "version": "0.3.3",
@@ -413,20 +410,13 @@
       "dev": true
     },
     "doctrine": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
-      "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
       "requires": {
-        "esutils": "2.0.2",
-        "isarray": "1.0.0"
+        "esutils": "2.0.2"
       }
-    },
-    "es6-promise": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz",
-      "integrity": "sha1-7FYjOGgDKQkgcXDDlEjiREndH8Q=",
-      "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -435,33 +425,33 @@
       "dev": true
     },
     "eslint": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.9.0.tgz",
-      "integrity": "sha1-doedJ0BoJhsZH+Dy9Wx0wvQgjos=",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.15.0.tgz",
+      "integrity": "sha512-zEO/Z1ZUxIQ+MhDVKkVTUYpIPDTEJLXGMrkID+5v1NeQHtCz6FZikWuFRgxE1Q/RV2V4zVl1u3xmpPADHhMZ6A==",
       "dev": true,
       "requires": {
-        "ajv": "5.3.0",
+        "ajv": "5.5.2",
         "babel-code-frame": "6.26.0",
         "chalk": "2.3.0",
         "concat-stream": "1.6.0",
         "cross-spawn": "5.1.0",
         "debug": "3.1.0",
-        "doctrine": "2.0.0",
+        "doctrine": "2.1.0",
         "eslint-scope": "3.7.1",
+        "eslint-visitor-keys": "1.0.0",
         "espree": "3.5.2",
         "esquery": "1.0.0",
-        "estraverse": "4.2.0",
         "esutils": "2.0.2",
         "file-entry-cache": "2.0.0",
         "functional-red-black-tree": "1.0.1",
         "glob": "7.1.2",
-        "globals": "9.18.0",
+        "globals": "11.1.0",
         "ignore": "3.3.7",
         "imurmurhash": "0.1.4",
         "inquirer": "3.3.0",
-        "is-resolvable": "1.0.0",
+        "is-resolvable": "1.1.0",
         "js-yaml": "3.10.0",
-        "json-stable-stringify": "1.0.1",
+        "json-stable-stringify-without-jsonify": "1.0.1",
         "levn": "0.3.0",
         "lodash": "4.17.4",
         "minimatch": "3.0.4",
@@ -472,7 +462,7 @@
         "pluralize": "7.0.0",
         "progress": "2.0.0",
         "require-uncached": "1.0.3",
-        "semver": "5.4.1",
+        "semver": "5.5.0",
         "strip-ansi": "4.0.0",
         "strip-json-comments": "2.0.1",
         "table": "4.0.2",
@@ -508,13 +498,19 @@
         "estraverse": "4.2.0"
       }
     },
+    "eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "dev": true
+    },
     "espree": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.2.tgz",
       "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
       "dev": true,
       "requires": {
-        "acorn": "5.2.1",
+        "acorn": "5.3.0",
         "acorn-jsx": "3.0.1"
       }
     },
@@ -556,13 +552,13 @@
       "dev": true
     },
     "external-editor": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.0.5.tgz",
-      "integrity": "sha512-Msjo64WT5W+NhOpQXh0nOHm+n0RfU1QUwDnKYvJ8dEJ8zlwLrqXNTv5mSUTJpepf41PDJGyhueTw2vNZW+Fr/w==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
+      "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
       "dev": true,
       "requires": {
+        "chardet": "0.4.2",
         "iconv-lite": "0.4.19",
-        "jschardet": "1.6.0",
         "tmp": "0.0.33"
       }
     },
@@ -601,16 +597,6 @@
       "requires": {
         "flat-cache": "1.3.0",
         "object-assign": "4.1.1"
-      }
-    },
-    "fill-keys": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
-      "integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
-      "dev": true,
-      "requires": {
-        "is-object": "1.0.1",
-        "merge-descriptors": "1.0.1"
       }
     },
     "find-rc": {
@@ -658,9 +644,9 @@
       }
     },
     "globals": {
-      "version": "9.18.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.1.0.tgz",
+      "integrity": "sha512-uEuWt9mqTlPDwSqi+sHjD4nWU/1N+q0fiWI9T1mZpD2UENqX20CFD5T/ziLZvztPaBKl7ZylUi1q6Qfm7E2CiQ==",
       "dev": true
     },
     "globby": {
@@ -695,12 +681,6 @@
         "uglify-js": "2.8.29"
       },
       "dependencies": {
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-          "dev": true
-        },
         "source-map": {
           "version": "0.4.4",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
@@ -800,7 +780,7 @@
         "chalk": "2.3.0",
         "cli-cursor": "2.1.0",
         "cli-width": "2.2.0",
-        "external-editor": "2.0.5",
+        "external-editor": "2.1.0",
         "figures": "2.0.0",
         "lodash": "4.17.4",
         "mute-stream": "0.0.7",
@@ -824,12 +804,6 @@
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
       "dev": true
     },
-    "is-object": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
-      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
-      "dev": true
-    },
     "is-path-cwd": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
@@ -842,13 +816,13 @@
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
       "dev": true,
       "requires": {
-        "is-path-inside": "1.0.0"
+        "is-path-inside": "1.0.1"
       }
     },
     "is-path-inside": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
-      "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
         "path-is-inside": "1.0.2"
@@ -861,13 +835,10 @@
       "dev": true
     },
     "is-resolvable": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
-      "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
-      "dev": true,
-      "requires": {
-        "tryit": "1.0.3"
-      }
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+      "dev": true
     },
     "isarray": {
       "version": "1.0.0",
@@ -876,9 +847,9 @@
       "dev": true
     },
     "isemail": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.0.0.tgz",
-      "integrity": "sha512-rz0ng/c+fX+zACpLgDB8fnUQ845WSU06f4hlhk4K8TJxmR6f5hyvitu9a9JdMD7aq/P4E0XdG1uaab2OiXgHlA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.1.0.tgz",
+      "integrity": "sha512-Ke15MBbbhyIhZzWheiWuRlTO81tTH4RQvrbJFpVzJce8oyVrCVSDdrcw4TcyMsaS/fMGJSbU3lTsqCGDKwrzww==",
       "requires": {
         "punycode": "2.1.0"
       }
@@ -890,12 +861,12 @@
       "dev": true
     },
     "joi": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-13.0.2.tgz",
-      "integrity": "sha512-kVka3LaHQyENvcMW4WJPSepGM43oCofcKxfs9HbbKd/FrwBAAt4lNNTPKOzSMmV53GIspmNO4U3O2TzoGvxxCA==",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-13.1.1.tgz",
+      "integrity": "sha512-Y44bDwIoeCjFDRO18VaMRc0hIdPkLbZaF2VqU7t1tCcno3S3XzsmlYYpOu0Qk6nkzoI5RSao7W57NTvPKxbkcg==",
       "requires": {
         "hoek": "5.0.2",
-        "isemail": "3.0.0",
+        "isemail": "3.1.0",
         "topo": "3.0.0"
       }
     },
@@ -915,12 +886,6 @@
         "esprima": "4.0.0"
       }
     },
-    "jschardet": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.6.0.tgz",
-      "integrity": "sha512-xYuhvQ7I9PDJIGBWev9xm0+SMSed3ZDBAmvVjbFR1ZRLAF+vlXcQu6cRI9uAlj81rzikElRVteehwV7DuX2ZmQ==",
-      "dev": true
-    },
     "json-schema-traverse": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
@@ -935,6 +900,12 @@
       "requires": {
         "jsonify": "0.0.0"
       }
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -958,14 +929,14 @@
       }
     },
     "lab": {
-      "version": "15.1.2",
-      "resolved": "https://registry.npmjs.org/lab/-/lab-15.1.2.tgz",
-      "integrity": "sha512-W7CnvFw/IOqLjeB9w66NIJbSpALEZyflt8HxD5Gp+kIvIRsG1vhX3WH9SCjsGR0o9T6FL//1vwt0pRJjwomf+Q==",
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/lab/-/lab-15.2.0.tgz",
+      "integrity": "sha512-3Ys7J3lzVx2nED/Jdkb7BMpdO8zAJGp9saQxS9Cbhe+EKDlv/dH108gKF7LgRJ/+kpuWEnCXCqfj2aqWeW6Drw==",
       "dev": true,
       "requires": {
         "bossy": "4.0.1",
         "diff": "3.4.0",
-        "eslint": "4.9.0",
+        "eslint": "4.15.0",
         "eslint-config-hapi": "11.1.0",
         "eslint-plugin-hapi": "4.1.0",
         "espree": "3.5.2",
@@ -977,8 +948,9 @@
         "mkdirp": "0.5.1",
         "seedrandom": "2.4.3",
         "source-map": "0.6.1",
-        "source-map-support": "0.5.0",
-        "supports-color": "4.4.0"
+        "source-map-support": "0.5.2",
+        "supports-color": "4.4.0",
+        "will-call": "1.0.1"
       }
     },
     "lazy-cache": {
@@ -1020,12 +992,6 @@
         "yallist": "2.1.2"
       }
     },
-    "merge-descriptors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
-      "dev": true
-    },
     "mimic-fn": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
@@ -1056,44 +1022,19 @@
         "minimist": "0.0.8"
       }
     },
-    "module-not-found-error": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
-      "integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=",
-      "dev": true
-    },
     "mongodb": {
-      "version": "2.2.33",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.33.tgz",
-      "integrity": "sha1-tTfEcdNKZlG0jzb9vyl1A0Dgi1A=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.0.1.tgz",
+      "integrity": "sha1-J47oAGJX7CJ5hZSmJZVGgl1t4bI=",
       "dev": true,
       "requires": {
-        "es6-promise": "3.2.1",
-        "mongodb-core": "2.1.17",
-        "readable-stream": "2.2.7"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.2.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.7.tgz",
-          "integrity": "sha1-BwV6y+JGeyIELTb5jFrVBwVOlbE=",
-          "dev": true,
-          "requires": {
-            "buffer-shims": "1.0.0",
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        }
+        "mongodb-core": "3.0.1"
       }
     },
     "mongodb-core": {
-      "version": "2.1.17",
-      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.17.tgz",
-      "integrity": "sha1-pBizN6FKFJkPtRC5I97mqBMXPfg=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-3.0.1.tgz",
+      "integrity": "sha1-/23Dbulv9ZaVPYCmhA1nMbyS7+0=",
       "dev": true,
       "requires": {
         "bson": "1.0.4",
@@ -1243,17 +1184,6 @@
       "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
       "dev": true
     },
-    "proxyquire": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-1.8.0.tgz",
-      "integrity": "sha1-AtUUpb7ZhvBMuyCTrxZ0FTX3ntw=",
-      "dev": true,
-      "requires": {
-        "fill-keys": "1.0.2",
-        "module-not-found-error": "1.0.1",
-        "resolve": "1.1.7"
-      }
-    },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
@@ -1303,7 +1233,7 @@
       "dev": true,
       "requires": {
         "resolve-from": "2.0.0",
-        "semver": "5.4.1"
+        "semver": "5.5.0"
       },
       "dependencies": {
         "resolve-from": {
@@ -1313,12 +1243,6 @@
           "dev": true
         }
       }
-    },
-    "resolve": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-      "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-      "dev": true
     },
     "resolve-from": {
       "version": "1.0.1",
@@ -1392,9 +1316,9 @@
       "dev": true
     },
     "semver": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
       "dev": true
     },
     "shebang-command": {
@@ -1434,9 +1358,9 @@
       "dev": true
     },
     "source-map-support": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.0.tgz",
-      "integrity": "sha512-vUoN3I7fHQe0R/SJLKRdKYuEdRGogsviXFkHHo17AWaTGv17VLnxw+CFXvqy+y4ORZ3doWLQcxRYfwKrsd/H7Q==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.2.tgz",
+      "integrity": "sha512-9zHceZbQwERaMK1MiFguvx1dL9GQPLXInr2D/wUxAsuV6ZKc9F0DHYWeloMcalkYRbtanwqUakoDjvj55cL/4A==",
       "dev": true,
       "requires": {
         "source-map": "0.6.1"
@@ -1505,7 +1429,7 @@
       "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
       "dev": true,
       "requires": {
-        "ajv": "5.3.0",
+        "ajv": "5.5.2",
         "ajv-keywords": "2.1.1",
         "chalk": "2.3.0",
         "lodash": "4.17.4",
@@ -1541,12 +1465,6 @@
       "requires": {
         "hoek": "5.0.2"
       }
-    },
-    "tryit": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
-      "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
-      "dev": true
     },
     "type-check": {
       "version": "0.3.2",
@@ -1605,6 +1523,12 @@
       "requires": {
         "isexe": "2.0.0"
       }
+    },
+    "will-call": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/will-call/-/will-call-1.0.1.tgz",
+      "integrity": "sha512-1hEeV8SfBYhNRc/bNXeQfyUBX8Dl9SCYME3qXh99iZP9wJcnhnlBsoBw8Y0lXVZ3YuPsoxImTzBiol1ouNR/hg==",
+      "dev": true
     },
     "window-size": {
       "version": "0.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,6 +78,15 @@
       "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
       "dev": true
     },
+    "ansi-red": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
+      "integrity": "sha1-jGOPnRCAgAo1PJwoyKgcpHBdlGw=",
+      "dev": true,
+      "requires": {
+        "ansi-wrap": "0.1.0"
+      }
+    },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -88,6 +97,12 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
+    },
+    "ansi-wrap": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
       "dev": true
     },
     "argparse": {
@@ -130,6 +145,12 @@
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+      "dev": true
+    },
+    "autolinker": {
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/autolinker/-/autolinker-0.15.3.tgz",
+      "integrity": "sha1-NCQX2PLzRhsUzwkIjV7fh5HcmDI=",
       "dev": true
     },
     "babel-code-frame": {
@@ -195,17 +216,6 @@
         "qs": "6.5.1",
         "raw-body": "2.3.2",
         "type-is": "1.6.15"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
       }
     },
     "boom": {
@@ -281,6 +291,15 @@
       "requires": {
         "align-text": "0.1.4",
         "lazy-cache": "1.0.4"
+      },
+      "dependencies": {
+        "lazy-cache": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+          "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "chalk": {
@@ -368,6 +387,12 @@
         "hoek": "5.0.2"
       }
     },
+    "coffee-script": {
+      "version": "1.12.7",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
+      "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw==",
+      "dev": true
+    },
     "color-convert": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
@@ -442,9 +467,9 @@
       }
     },
     "debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
       "requires": {
         "ms": "2.0.0"
@@ -488,6 +513,12 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+      "dev": true
+    },
+    "diacritics-map": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/diacritics-map/-/diacritics-map-0.1.0.tgz",
+      "integrity": "sha1-bfwP+dAQAKLt8oZTccrDFulJd68=",
       "dev": true
     },
     "diff": {
@@ -572,6 +603,17 @@
         "strip-json-comments": "2.0.1",
         "table": "4.0.2",
         "text-table": "0.2.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "eslint-config-hapi": {
@@ -662,6 +704,15 @@
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
     },
+    "expand-range": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+      "dev": true,
+      "requires": {
+        "fill-range": "2.2.3"
+      }
+    },
     "express": {
       "version": "4.16.2",
       "resolved": "https://registry.npmjs.org/express/-/express-4.16.2.tgz",
@@ -700,15 +751,27 @@
         "vary": "1.1.2"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
+        "setprototypeof": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+          "dev": true
+        },
+        "statuses": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
+          "dev": true
         }
+      }
+    },
+    "extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "dev": true,
+      "requires": {
+        "is-extendable": "0.1.1"
       }
     },
     "external-editor": {
@@ -759,6 +822,19 @@
         "object-assign": "4.1.1"
       }
     },
+    "fill-range": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+      "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+      "dev": true,
+      "requires": {
+        "is-number": "2.1.0",
+        "isobject": "2.1.0",
+        "randomatic": "1.1.7",
+        "repeat-element": "1.1.2",
+        "repeat-string": "1.6.1"
+      }
+    },
     "finalhandler": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
@@ -774,14 +850,11 @@
         "unpipe": "1.0.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
+        "statuses": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
+          "dev": true
         }
       }
     },
@@ -802,6 +875,12 @@
         "graceful-fs": "4.1.11",
         "write": "0.2.1"
       }
+    },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true
     },
     "forwarded": {
       "version": "0.1.2",
@@ -867,6 +946,19 @@
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
       "dev": true
     },
+    "gray-matter": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-2.1.1.tgz",
+      "integrity": "sha1-MELZrewqHe1qdwep7SOA+KF6Qw4=",
+      "dev": true,
+      "requires": {
+        "ansi-red": "0.1.1",
+        "coffee-script": "1.12.7",
+        "extend-shallow": "2.0.1",
+        "js-yaml": "3.10.0",
+        "toml": "2.3.3"
+      }
+    },
     "handlebars": {
       "version": "4.0.11",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
@@ -914,6 +1006,15 @@
       "integrity": "sha1-dJWnJv5yt7yo3izcwdh82M5qtPI=",
       "dev": true
     },
+    "hapitoc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hapitoc/-/hapitoc-1.2.0.tgz",
+      "integrity": "sha512-yKVJBPrTCwdVdwUOZU5B1tVEN8mgNl3A5rfeOowHpsfuodKjLkmnbzlD5anaZDMfq5kTiQkt1s8ATIFOrhxacA==",
+      "dev": true,
+      "requires": {
+        "markdown-toc": "1.2.0"
+      }
+    },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
@@ -943,19 +1044,13 @@
         "depd": "1.1.1",
         "inherits": "2.0.3",
         "setprototypeof": "1.0.3",
-        "statuses": "1.3.1"
+        "statuses": "1.4.0"
       },
       "dependencies": {
         "depd": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
           "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
-          "dev": true
-        },
-        "setprototypeof": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
-          "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
           "dev": true
         }
       }
@@ -1028,11 +1123,26 @@
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
     },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true
+    },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
       "dev": true
+    },
+    "is-number": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      }
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -1056,6 +1166,23 @@
       "dev": true,
       "requires": {
         "path-is-inside": "1.0.2"
+      }
+    },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "requires": {
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
       }
     },
     "is-promise": {
@@ -1089,6 +1216,15 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
+    },
+    "isobject": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+      "dev": true,
+      "requires": {
+        "isarray": "1.0.0"
+      }
     },
     "joi": {
       "version": "13.1.1",
@@ -1184,11 +1320,13 @@
       }
     },
     "lazy-cache": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+      "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
       "dev": true,
-      "optional": true
+      "requires": {
+        "set-getter": "0.1.0"
+      }
     },
     "levn": {
       "version": "0.3.0",
@@ -1198,6 +1336,18 @@
       "requires": {
         "prelude-ls": "1.1.2",
         "type-check": "0.3.2"
+      }
+    },
+    "list-item": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/list-item/-/list-item-1.1.1.tgz",
+      "integrity": "sha1-DGXQDih8tmPMs8s4Sad+iewmilY=",
+      "dev": true,
+      "requires": {
+        "expand-range": "1.8.2",
+        "extend-shallow": "2.0.1",
+        "is-number": "2.1.0",
+        "repeat-string": "1.6.1"
       }
     },
     "lodash": {
@@ -1220,6 +1370,32 @@
       "requires": {
         "pseudomap": "1.0.2",
         "yallist": "2.1.2"
+      }
+    },
+    "markdown-link": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-link/-/markdown-link-0.1.1.tgz",
+      "integrity": "sha1-MsXGUZmmRXMWMi0eQinRNAfIx88=",
+      "dev": true
+    },
+    "markdown-toc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-toc/-/markdown-toc-1.2.0.tgz",
+      "integrity": "sha512-eOsq7EGd3asV0oBfmyqngeEIhrbkc7XVP63OwcJBIhH2EpG2PzFcbZdhy1jutXSlRBBVMNXHvMtSr5LAxSUvUg==",
+      "dev": true,
+      "requires": {
+        "concat-stream": "1.6.0",
+        "diacritics-map": "0.1.0",
+        "gray-matter": "2.1.1",
+        "lazy-cache": "2.0.2",
+        "list-item": "1.1.1",
+        "markdown-link": "0.1.1",
+        "minimist": "1.2.0",
+        "mixin-deep": "1.3.0",
+        "object.pick": "1.3.0",
+        "remarkable": "1.7.1",
+        "repeat-string": "1.6.1",
+        "strip-color": "0.1.0"
       }
     },
     "media-typer": {
@@ -1277,10 +1453,31 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true
+    },
+    "mixin-deep": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.0.tgz",
+      "integrity": "sha512-dgaCvoh6i1nosAUBKb0l0pfJ78K8+S9fluyIR2YvAeUD/QuMahnFnF3xYty5eYXMjhGSsB0DsW6A0uAZyetoAg==",
+      "dev": true,
+      "requires": {
+        "for-in": "1.0.2",
+        "is-extendable": "1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "2.0.4"
+          }
+        }
+      }
     },
     "mkdirp": {
       "version": "0.5.1",
@@ -1289,6 +1486,14 @@
       "dev": true,
       "requires": {
         "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        }
       }
     },
     "mongodb": {
@@ -1346,6 +1551,23 @@
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
     },
+    "object.pick": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "dev": true,
+      "requires": {
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
     "on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -1379,10 +1601,16 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8",
+        "minimist": "0.0.10",
         "wordwrap": "0.0.3"
       },
       "dependencies": {
+        "minimist": {
+          "version": "0.0.10",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+          "dev": true
+        },
         "wordwrap": {
           "version": "0.0.3",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
@@ -1507,6 +1735,47 @@
       "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
       "dev": true
     },
+    "randomatic": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+      "dev": true,
+      "requires": {
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
     "range-parser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
@@ -1539,6 +1808,34 @@
         "string_decoder": "1.0.3",
         "util-deprecate": "1.0.2"
       }
+    },
+    "remarkable": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/remarkable/-/remarkable-1.7.1.tgz",
+      "integrity": "sha1-qspJchALZqZCpjoQIcpLrBvjv/Y=",
+      "dev": true,
+      "requires": {
+        "argparse": "0.1.16",
+        "autolinker": "0.15.3"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "0.1.16",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+          "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
+          "dev": true,
+          "requires": {
+            "underscore": "1.7.0",
+            "underscore.string": "2.4.0"
+          }
+        }
+      }
+    },
+    "repeat-element": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+      "dev": true
     },
     "repeat-string": {
       "version": "1.6.1",
@@ -1672,14 +1969,11 @@
         "statuses": "1.3.1"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
+        "statuses": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
+          "dev": true
         }
       }
     },
@@ -1695,10 +1989,19 @@
         "send": "0.16.1"
       }
     },
+    "set-getter": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/set-getter/-/set-getter-0.1.0.tgz",
+      "integrity": "sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=",
+      "dev": true,
+      "requires": {
+        "to-object-path": "0.3.0"
+      }
+    },
     "setprototypeof": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+      "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
       "dev": true
     },
     "shebang-command": {
@@ -1753,9 +2056,9 @@
       "dev": true
     },
     "statuses": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-      "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+      "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
       "dev": true
     },
     "string-width": {
@@ -1793,6 +2096,12 @@
           "dev": true
         }
       }
+    },
+    "strip-color": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/strip-color/-/strip-color-0.1.0.tgz",
+      "integrity": "sha1-EG9l09PmotlAHKwOsM6LinArT3s=",
+      "dev": true
     },
     "strip-json-comments": {
       "version": "2.0.1",
@@ -1843,6 +2152,21 @@
       "requires": {
         "os-tmpdir": "1.0.2"
       }
+    },
+    "to-object-path": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      }
+    },
+    "toml": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-2.3.3.tgz",
+      "integrity": "sha512-O7L5hhSQHxuufWUdcTRPfuTh3phKfAZ/dqfxZFoxPCj2RYmpaSGLEIs016FCXItQwNr08yefUB5TSjzRYnajTA==",
+      "dev": true
     },
     "topo": {
       "version": "3.0.0",
@@ -1904,6 +2228,18 @@
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
       "dev": true,
       "optional": true
+    },
+    "underscore": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+      "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=",
+      "dev": true
+    },
+    "underscore.string": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+      "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs=",
+      "dev": true
     },
     "unpipe": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2,11 +2,12 @@
   "name": "mongo-models",
   "version": "1.4.0",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "acorn": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz",
-      "integrity": "sha512-vOk6uEMctu0vQrvuSqFdJyqj1Q0S5VTDL79qtjo+DhRr+1mmaD+tluFSCZqhvi/JUhXSzoZN2BhtstaPEeE8cw==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
+      "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w==",
       "dev": true
     },
     "acorn-jsx": {
@@ -14,6 +15,9 @@
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
+      "requires": {
+        "acorn": "3.3.0"
+      },
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
@@ -24,22 +28,33 @@
       }
     },
     "ajv": {
-      "version": "4.11.8",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-      "dev": true
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
+      "integrity": "sha1-RBT/dKUIecII7l/cgm4ywwNUnto=",
+      "dev": true,
+      "requires": {
+        "co": "4.6.0",
+        "fast-deep-equal": "1.0.0",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
+      }
     },
     "ajv-keywords": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
-      "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+      "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
       "dev": true
     },
     "align-text": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2",
+        "longest": "1.0.1",
+        "repeat-string": "1.6.1"
+      }
     },
     "amdefine": {
       "version": "1.0.1",
@@ -48,9 +63,9 @@
       "dev": true
     },
     "ansi-escapes": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-2.0.0.tgz",
-      "integrity": "sha1-W65SvkJIeN2Xg+iRDj/Cki6DyBs=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
+      "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
       "dev": true
     },
     "ansi-regex": {
@@ -69,19 +84,19 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-      "dev": true
-    },
-    "array-find-index": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "sprintf-js": "1.0.3"
+      }
     },
     "array-union": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-uniq": "1.0.3"
+      }
     },
     "array-uniq": {
       "version": "1.0.3",
@@ -96,15 +111,54 @@
       "dev": true
     },
     "async": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-      "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw=="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+      "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.4"
+      }
     },
     "babel-code-frame": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-      "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
-      "dev": true
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -112,17 +166,35 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
+    "boom": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-7.1.1.tgz",
+      "integrity": "sha512-qwEARHTliqgEQiVkzKkkbLt3q0vRPIW60VRZ8zRnbjsm7INkPe9NxfAYDDYLZOdhxyUHa1gIe639Cx7t6RH/4A==",
+      "dev": true,
+      "requires": {
+        "hoek": "5.0.2"
+      }
+    },
     "bossy": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/bossy/-/bossy-3.0.4.tgz",
-      "integrity": "sha1-+a6fJugbQaMY9O4Ng2huSlwlB7k=",
-      "dev": true
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bossy/-/bossy-4.0.1.tgz",
+      "integrity": "sha512-IrXZdXnDrjfk9ZVtnnmehlcTGK/KRqUJuNZJteMGU2/cJdXC6yWf2yhkAAbAgjOTsJJHXdlYloTeFH1ZgRNllw==",
+      "dev": true,
+      "requires": {
+        "boom": "7.1.1",
+        "hoek": "5.0.2",
+        "joi": "13.0.2"
+      }
     },
     "brace-expansion": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
     },
     "bson": {
       "version": "1.0.4",
@@ -136,17 +208,14 @@
       "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
       "dev": true
     },
-    "builtin-modules": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-      "dev": true
-    },
     "caller-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "callsites": "0.2.0"
+      }
     },
     "callsites": {
       "version": "0.2.0",
@@ -161,32 +230,38 @@
       "dev": true,
       "optional": true
     },
-    "camelcase-keys": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-      "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-      "dev": true,
-      "dependencies": {
-        "camelcase": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-          "dev": true
-        }
-      }
-    },
     "center-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "align-text": "0.1.4",
+        "lazy-cache": "1.0.4"
+      }
     },
     "chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-      "dev": true
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+      "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "3.2.0",
+        "escape-string-regexp": "1.0.5",
+        "supports-color": "4.4.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        }
+      }
     },
     "circular-json": {
       "version": "0.3.3",
@@ -198,12 +273,15 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "restore-cursor": "2.0.0"
+      }
     },
     "cli-width": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
-      "integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
     "cliui": {
@@ -212,6 +290,11 @@
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
       "dev": true,
       "optional": true,
+      "requires": {
+        "center-align": "0.1.3",
+        "right-align": "0.1.3",
+        "wordwrap": "0.0.2"
+      },
       "dependencies": {
         "wordwrap": {
           "version": "0.0.2",
@@ -229,16 +312,22 @@
       "dev": true
     },
     "code": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/code/-/code-4.1.0.tgz",
-      "integrity": "sha1-IJrRHQWvigwceq9pTZ+k0sfZW4U=",
-      "dev": true
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/code/-/code-5.1.2.tgz",
+      "integrity": "sha512-Typ0BuWOKPGNOY9M7hBDY60J9uSPok4Y7hhtTG/3Cpqg0/AhauZSWax0Mb0lZuzm89w1YgVvl8BTrBW/4Sw6sw==",
+      "dev": true,
+      "requires": {
+        "hoek": "5.0.2"
+      }
     },
     "color-convert": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
-      "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
-      "dev": true
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
     },
     "color-name": {
       "version": "1.1.3",
@@ -256,7 +345,12 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3",
+        "typedarray": "0.0.6"
+      }
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -264,23 +358,32 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
-    "currently-unhandled": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-      "dev": true
+    "cross-spawn": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "4.1.1",
+        "shebang-command": "1.2.0",
+        "which": "1.3.0"
+      }
     },
     "debug": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-      "dev": true
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
     },
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "deep-is": {
       "version": "0.1.3",
@@ -292,25 +395,32 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "globby": "5.0.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.0",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "rimraf": "2.6.2"
+      }
     },
     "diff": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.0.tgz",
-      "integrity": "sha512-w0XZubFWn0Adlsapj9EAWX0FqWdO4tz8kc3RiYdWLh4k/V8PTb6i0SMgXt0vRM3zyKnT8tKO7mUlieRQHIjMNg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
+      "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA==",
       "dev": true
     },
     "doctrine": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
       "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
-      "dev": true
-    },
-    "error-ex": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "esutils": "2.0.2",
+        "isarray": "1.0.0"
+      }
     },
     "es6-promise": {
       "version": "3.2.1",
@@ -325,34 +435,88 @@
       "dev": true
     },
     "eslint": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.0.0.tgz",
-      "integrity": "sha1-cnfAFDf99B3M0WjVqg5Jt1yh8mA=",
-      "dev": true
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.9.0.tgz",
+      "integrity": "sha1-doedJ0BoJhsZH+Dy9Wx0wvQgjos=",
+      "dev": true,
+      "requires": {
+        "ajv": "5.3.0",
+        "babel-code-frame": "6.26.0",
+        "chalk": "2.3.0",
+        "concat-stream": "1.6.0",
+        "cross-spawn": "5.1.0",
+        "debug": "3.1.0",
+        "doctrine": "2.0.0",
+        "eslint-scope": "3.7.1",
+        "espree": "3.5.2",
+        "esquery": "1.0.0",
+        "estraverse": "4.2.0",
+        "esutils": "2.0.2",
+        "file-entry-cache": "2.0.0",
+        "functional-red-black-tree": "1.0.1",
+        "glob": "7.1.2",
+        "globals": "9.18.0",
+        "ignore": "3.3.7",
+        "imurmurhash": "0.1.4",
+        "inquirer": "3.3.0",
+        "is-resolvable": "1.0.0",
+        "js-yaml": "3.10.0",
+        "json-stable-stringify": "1.0.1",
+        "levn": "0.3.0",
+        "lodash": "4.17.4",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "natural-compare": "1.4.0",
+        "optionator": "0.8.2",
+        "path-is-inside": "1.0.2",
+        "pluralize": "7.0.0",
+        "progress": "2.0.0",
+        "require-uncached": "1.0.3",
+        "semver": "5.4.1",
+        "strip-ansi": "4.0.0",
+        "strip-json-comments": "2.0.1",
+        "table": "4.0.2",
+        "text-table": "0.2.0"
+      }
     },
     "eslint-config-hapi": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-hapi/-/eslint-config-hapi-10.0.0.tgz",
-      "integrity": "sha1-mYCv/XYQPrwf7JK0Vjg0XbGTSPU=",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-hapi/-/eslint-config-hapi-11.1.0.tgz",
+      "integrity": "sha512-fCw0uLgkZLQBqYu/lR5MA6cXB+D4c2EEtzrVmhHbGQq3iRCFSaUEOE/N4Sujd1Qh5jkaUc0/kuB/gdv2upt5aQ==",
       "dev": true
     },
     "eslint-plugin-hapi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-hapi/-/eslint-plugin-hapi-4.0.0.tgz",
-      "integrity": "sha1-RKouRfeTmlI5Kc2DK7mqEpqV6CM=",
-      "dev": true
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-hapi/-/eslint-plugin-hapi-4.1.0.tgz",
+      "integrity": "sha512-z1yUoSWArx6pXaC0FoWRFpqjbHn8QWonJiTVhJmiC14jOAT7FZKdKWCkhM4jQrgrkEK9YEv3p2HuzSf5dtWmuQ==",
+      "dev": true,
+      "requires": {
+        "hapi-capitalize-modules": "1.1.6",
+        "hapi-for-you": "1.0.0",
+        "hapi-no-var": "1.0.1",
+        "hapi-scope-start": "2.1.1",
+        "no-arrowception": "1.0.0"
+      }
     },
     "eslint-scope": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
       "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "esrecurse": "4.2.0",
+        "estraverse": "4.2.0"
+      }
     },
     "espree": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.4.3.tgz",
-      "integrity": "sha1-KRC1zNSc6JPC//+qtP2LOjG4I3Q=",
-      "dev": true
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.2.tgz",
+      "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
+      "dev": true,
+      "requires": {
+        "acorn": "5.2.1",
+        "acorn-jsx": "3.0.1"
+      }
     },
     "esprima": {
       "version": "4.0.0",
@@ -364,13 +528,20 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
       "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "estraverse": "4.2.0"
+      }
     },
     "esrecurse": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
       "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "estraverse": "4.2.0",
+        "object-assign": "4.1.1"
+      }
     },
     "estraverse": {
       "version": "4.2.0",
@@ -385,9 +556,26 @@
       "dev": true
     },
     "external-editor": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.0.4.tgz",
-      "integrity": "sha1-HtkZnanL/i7y96MbL96LDRI2iXI=",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.0.5.tgz",
+      "integrity": "sha512-Msjo64WT5W+NhOpQXh0nOHm+n0RfU1QUwDnKYvJ8dEJ8zlwLrqXNTv5mSUTJpepf41PDJGyhueTw2vNZW+Fr/w==",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "0.4.19",
+        "jschardet": "1.6.0",
+        "tmp": "0.0.33"
+      }
+    },
+    "fast-deep-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
+      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
       "dev": true
     },
     "fast-levenshtein": {
@@ -400,25 +588,30 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "1.0.5"
+      }
     },
     "file-entry-cache": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
-      "dev": true
-    },
-    "file-type": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
-      "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "flat-cache": "1.3.0",
+        "object-assign": "4.1.1"
+      }
     },
     "fill-keys": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
       "integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-object": "1.0.1",
+        "merge-descriptors": "1.0.1"
+      }
     },
     "find-rc": {
       "version": "3.0.1",
@@ -426,17 +619,17 @@
       "integrity": "sha1-VKQXg3DxC8k3H6jRssKAmir6DM4=",
       "dev": true
     },
-    "find-up": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-      "dev": true
-    },
     "flat-cache": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
-      "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
-      "dev": true
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
+      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+      "dev": true,
+      "requires": {
+        "circular-json": "0.3.3",
+        "del": "2.2.2",
+        "graceful-fs": "4.1.11",
+        "write": "0.2.1"
+      }
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -444,29 +637,25 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
-    "generate-function": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
-      "dev": true
-    },
-    "generate-object-property": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "dev": true
-    },
-    "get-stdin": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
-      "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
     },
     "globals": {
       "version": "9.18.0",
@@ -478,7 +667,15 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "glob": "7.1.2",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
+      }
     },
     "graceful-fs": {
       "version": "4.1.11",
@@ -487,10 +684,16 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
-      "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
+      "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
       "dev": true,
+      "requires": {
+        "async": "1.5.2",
+        "optimist": "0.6.1",
+        "source-map": "0.4.4",
+        "uglify-js": "2.8.29"
+      },
       "dependencies": {
         "async": {
           "version": "1.5.2",
@@ -502,7 +705,10 @@
           "version": "0.4.4",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
         }
       }
     },
@@ -518,6 +724,12 @@
       "integrity": "sha1-02L77o172pwseAHiB+WlzRoLans=",
       "dev": true
     },
+    "hapi-no-var": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hapi-no-var/-/hapi-no-var-1.0.1.tgz",
+      "integrity": "sha512-kk2xyyTzI+eQ/oA1rO4eVdCpYsrPHVERHa6+mTHD08XXFLaAkkaEs6reMg1VyqGh2o5xPt//DO4EhCacLx/cRA==",
+      "dev": true
+    },
     "hapi-scope-start": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/hapi-scope-start/-/hapi-scope-start-2.1.1.tgz",
@@ -528,7 +740,10 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
     },
     "has-flag": {
       "version": "2.0.0",
@@ -537,26 +752,20 @@
       "dev": true
     },
     "hoek": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
-    },
-    "hosted-git-info": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
-      "dev": true
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.2.tgz",
+      "integrity": "sha512-NA10UYP9ufCtY2qYGkZktcQXwVyYK4zK0gkaFSB96xhtlo6V8tKXdQgx8eHolQTRemaW0uLn8BhjhwqrOU+QLQ=="
     },
     "iconv-lite": {
-      "version": "0.4.18",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz",
-      "integrity": "sha512-sr1ZQph3UwHTR0XftSbK85OvBbxe/abLGzEnPENCQwmHf7sck8Oyu4ob3LgBxWWxRoM+QszeUyl7jbqapu2TqA==",
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
       "dev": true
     },
     "ignore": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.3.tgz",
-      "integrity": "sha1-QyNS5XrM2HqzEQ6C0/6g5HgSFW0=",
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
+      "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
       "dev": true
     },
     "imurmurhash": {
@@ -565,17 +774,15 @@
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
-    "indent-string": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-      "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-      "dev": true
-    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
     },
     "inherits": {
       "version": "2.0.3",
@@ -584,77 +791,37 @@
       "dev": true
     },
     "inquirer": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.2.1.tgz",
-      "integrity": "sha512-QgW3eiPN8gpj/K5vVpHADJJgrrF0ho/dZGylikGX7iqAdRgC9FVKYKWFLx6hZDBFcOLEoSqINYrVPeFAeG/PdA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
       "dev": true,
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true
-        },
-        "chalk": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
-          "integrity": "sha512-qxzYsob3yv6U+xMzPrv170y8AwGP7i74g+pbixCfD6rgso8BscLT2qXIuz6TpOaiJZ3mFgT5O9lyT9nMU4LfaA==",
-          "dev": true
-        }
+      "requires": {
+        "ansi-escapes": "3.0.0",
+        "chalk": "2.3.0",
+        "cli-cursor": "2.1.0",
+        "cli-width": "2.2.0",
+        "external-editor": "2.0.5",
+        "figures": "2.0.0",
+        "lodash": "4.17.4",
+        "mute-stream": "0.0.7",
+        "run-async": "2.3.0",
+        "rx-lite": "4.0.8",
+        "rx-lite-aggregates": "4.0.8",
+        "string-width": "2.1.1",
+        "strip-ansi": "4.0.0",
+        "through": "2.3.8"
       }
     },
-    "is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-      "dev": true
-    },
     "is-buffer": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
-      "dev": true
-    },
-    "is-builtin-module": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-      "dev": true
-    },
-    "is-finite": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-      "dev": true
-    },
-    "is-my-json-valid": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
-      "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
       "dev": true
     },
     "is-object": {
@@ -673,13 +840,19 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-path-inside": "1.0.0"
+      }
     },
     "is-path-inside": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
       "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "path-is-inside": "1.0.2"
+      }
     },
     "is-promise": {
       "version": "2.1.0",
@@ -687,23 +860,14 @@
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
     },
-    "is-property": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
-      "dev": true
-    },
     "is-resolvable": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
       "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
-      "dev": true
-    },
-    "is-utf8": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "tryit": "1.0.3"
+      }
     },
     "isarray": {
       "version": "1.0.0",
@@ -712,19 +876,28 @@
       "dev": true
     },
     "isemail": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isemail/-/isemail-2.2.1.tgz",
-      "integrity": "sha1-A1PT2aYpUQgMJiwqoKQrjqjp4qY="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.0.0.tgz",
+      "integrity": "sha512-rz0ng/c+fX+zACpLgDB8fnUQ845WSU06f4hlhk4K8TJxmR6f5hyvitu9a9JdMD7aq/P4E0XdG1uaab2OiXgHlA==",
+      "requires": {
+        "punycode": "2.1.0"
+      }
     },
-    "items": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/items/-/items-2.1.1.tgz",
-      "integrity": "sha1-i9FtnIOxlSneWuoyGsqtp4NkoZg="
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
     },
     "joi": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
-      "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ=="
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-13.0.2.tgz",
+      "integrity": "sha512-kVka3LaHQyENvcMW4WJPSepGM43oCofcKxfs9HbbKd/FrwBAAt4lNNTPKOzSMmV53GIspmNO4U3O2TzoGvxxCA==",
+      "requires": {
+        "hoek": "5.0.2",
+        "isemail": "3.0.0",
+        "topo": "3.0.0"
+      }
     },
     "js-tokens": {
       "version": "3.0.2",
@@ -733,22 +906,35 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.1.tgz",
-      "integrity": "sha512-CbcG379L1e+mWBnLvHWWeLs8GyV/EMw862uLI3c+GxVyDHWZcjZinwuBd3iW2pgxgIlksW/1vNJa4to+RvDOww==",
-      "dev": true
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+      "dev": true,
+      "requires": {
+        "argparse": "1.0.9",
+        "esprima": "4.0.0"
+      }
     },
     "jschardet": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.5.1.tgz",
-      "integrity": "sha512-vE2hT1D0HLZCLLclfBSfkfTTedhVj0fubHpJBHKwwUWX0nSbhPAfk+SG9rTX95BYNmau8rGFfCeaT6T5OW1C2A==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.6.0.tgz",
+      "integrity": "sha512-xYuhvQ7I9PDJIGBWev9xm0+SMSed3ZDBAmvVjbFR1ZRLAF+vlXcQu6cRI9uAlj81rzikElRVteehwV7DuX2ZmQ==",
+      "dev": true
+    },
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
       "dev": true
     },
     "json-stable-stringify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "jsonify": "0.0.0"
+      }
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -762,23 +948,38 @@
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
       "dev": true
     },
-    "jsonpointer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
-      "dev": true
-    },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-buffer": "1.1.6"
+      }
     },
     "lab": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/lab/-/lab-14.1.1.tgz",
-      "integrity": "sha512-kfSwUxfmXbi191a2T0P3BNc4tDSoTw6i5QvoGTuPQiJ1Cx0Q6D7ZZwiNqxyJtjoZDO7fGhX0eGCir8FCSpc6Tw==",
-      "dev": true
+      "version": "15.1.2",
+      "resolved": "https://registry.npmjs.org/lab/-/lab-15.1.2.tgz",
+      "integrity": "sha512-W7CnvFw/IOqLjeB9w66NIJbSpALEZyflt8HxD5Gp+kIvIRsG1vhX3WH9SCjsGR0o9T6FL//1vwt0pRJjwomf+Q==",
+      "dev": true,
+      "requires": {
+        "bossy": "4.0.1",
+        "diff": "3.4.0",
+        "eslint": "4.9.0",
+        "eslint-config-hapi": "11.1.0",
+        "eslint-plugin-hapi": "4.1.0",
+        "espree": "3.5.2",
+        "find-rc": "3.0.1",
+        "handlebars": "4.0.11",
+        "hoek": "5.0.2",
+        "json-stable-stringify": "1.0.1",
+        "json-stringify-safe": "5.0.1",
+        "mkdirp": "0.5.1",
+        "seedrandom": "2.4.3",
+        "source-map": "0.6.1",
+        "source-map-support": "0.5.0",
+        "supports-color": "4.4.0"
+      }
     },
     "lazy-cache": {
       "version": "1.0.4",
@@ -791,18 +992,17 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true
-    },
-    "load-json-file": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
+      }
     },
     "lodash": {
       "version": "4.17.4",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+      "dev": true
     },
     "longest": {
       "version": "1.0.1",
@@ -810,30 +1010,14 @@
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
       "dev": true
     },
-    "loud-rejection": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-      "dev": true
-    },
-    "map-obj": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-      "dev": true
-    },
-    "meow": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-      "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+    "lru-cache": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
       "dev": true,
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        }
+      "requires": {
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
       }
     },
     "merge-descriptors": {
@@ -852,7 +1036,10 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
     },
     "minimist": {
       "version": "0.0.8",
@@ -864,7 +1051,10 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
     },
     "module-not-found-error": {
       "version": "1.0.1",
@@ -873,24 +1063,42 @@
       "dev": true
     },
     "mongodb": {
-      "version": "2.2.31",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.31.tgz",
-      "integrity": "sha1-GUBEXGYeGSF7s7+CRdmFSq71SNs=",
+      "version": "2.2.33",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.33.tgz",
+      "integrity": "sha1-tTfEcdNKZlG0jzb9vyl1A0Dgi1A=",
       "dev": true,
+      "requires": {
+        "es6-promise": "3.2.1",
+        "mongodb-core": "2.1.17",
+        "readable-stream": "2.2.7"
+      },
       "dependencies": {
         "readable-stream": {
           "version": "2.2.7",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.7.tgz",
           "integrity": "sha1-BwV6y+JGeyIELTb5jFrVBwVOlbE=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "buffer-shims": "1.0.0",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
         }
       }
     },
     "mongodb-core": {
-      "version": "2.1.15",
-      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.15.tgz",
-      "integrity": "sha1-hB9TuH//9MdFgYnDXIroJ+EWl2Q=",
-      "dev": true
+      "version": "2.1.17",
+      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.17.tgz",
+      "integrity": "sha1-pBizN6FKFJkPtRC5I97mqBMXPfg=",
+      "dev": true,
+      "requires": {
+        "bson": "1.0.4",
+        "require_optional": "1.0.1"
+      }
     },
     "ms": {
       "version": "2.0.0",
@@ -916,18 +1124,6 @@
       "integrity": "sha1-W/PpXrnEG1c4SoBTM9qjtzTuMno=",
       "dev": true
     },
-    "normalize-package-data": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
-      "dev": true
-    },
-    "number-is-nan": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "dev": true
-    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -938,31 +1134,29 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
     },
     "onetime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-      "dev": true
-    },
-    "opn": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
-      "integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
-      "dev": true
-    },
-    "opn-cli": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/opn-cli/-/opn-cli-3.1.0.tgz",
-      "integrity": "sha1-+BmubK4LQRvQFJuFYP5siK2tIPg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "mimic-fn": "1.1.0"
+      }
     },
     "optimist": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
+      "requires": {
+        "minimist": "0.0.8",
+        "wordwrap": "0.0.3"
+      },
       "dependencies": {
         "wordwrap": {
           "version": "0.0.3",
@@ -976,24 +1170,20 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
+      }
     },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true
-    },
-    "parse-json": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-      "dev": true
-    },
-    "path-exists": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
       "dev": true
     },
     "path-is-absolute": {
@@ -1006,12 +1196,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
       "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
-      "dev": true
-    },
-    "path-type": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "dev": true
     },
     "pify": {
@@ -1030,12 +1214,15 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pinkie": "2.0.4"
+      }
     },
     "pluralize": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-4.0.0.tgz",
-      "integrity": "sha1-WbcIwcAZCi9pLxx2GMRGsFL9F2I=",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
       "dev": true
     },
     "prelude-ls": {
@@ -1060,31 +1247,38 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-1.8.0.tgz",
       "integrity": "sha1-AtUUpb7ZhvBMuyCTrxZ0FTX3ntw=",
+      "dev": true,
+      "requires": {
+        "fill-keys": "1.0.2",
+        "module-not-found-error": "1.0.1",
+        "resolve": "1.1.7"
+      }
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
-    "read-pkg": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-      "dev": true
-    },
-    "read-pkg-up": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-      "dev": true
+    "punycode": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+      "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
     },
     "readable-stream": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
       "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-      "dev": true
-    },
-    "redent": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-      "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "1.0.7",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.0.3",
+        "util-deprecate": "1.0.2"
+      }
     },
     "repeat-string": {
       "version": "1.6.1",
@@ -1092,17 +1286,25 @@
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true
     },
-    "repeating": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-      "dev": true
+    "require-uncached": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+      "dev": true,
+      "requires": {
+        "caller-path": "0.1.0",
+        "resolve-from": "1.0.1"
+      }
     },
     "require_optional": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
       "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
       "dev": true,
+      "requires": {
+        "resolve-from": "2.0.0",
+        "semver": "5.4.1"
+      },
       "dependencies": {
         "resolve-from": {
           "version": "2.0.0",
@@ -1111,12 +1313,6 @@
           "dev": true
         }
       }
-    },
-    "require-uncached": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
-      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-      "dev": true
     },
     "resolve": {
       "version": "1.1.7",
@@ -1134,26 +1330,39 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "onetime": "2.0.1",
+        "signal-exit": "3.0.2"
+      }
     },
     "right-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "align-text": "0.1.4"
+      }
     },
     "rimraf": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-      "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
-      "dev": true
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2"
+      }
     },
     "run-async": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-promise": "2.1.0"
+      }
     },
     "rx-lite": {
       "version": "4.0.8",
@@ -1165,7 +1374,10 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
       "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "rx-lite": "4.0.8"
+      }
     },
     "safe-buffer": {
       "version": "5.1.1",
@@ -1185,6 +1397,21 @@
       "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
       "dev": true
     },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -1192,40 +1419,28 @@
       "dev": true
     },
     "slice-ansi": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
-      "dev": true
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "2.0.0"
+      }
     },
     "source-map": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-      "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true
     },
     "source-map-support": {
-      "version": "0.4.15",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
-      "integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E=",
-      "dev": true
-    },
-    "spdx-correct": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-      "dev": true
-    },
-    "spdx-expression-parse": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
-      "dev": true
-    },
-    "spdx-license-ids": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
-      "dev": true
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.0.tgz",
+      "integrity": "sha512-vUoN3I7fHQe0R/SJLKRdKYuEdRGogsviXFkHHo17AWaTGv17VLnxw+CFXvqy+y4ORZ3doWLQcxRYfwKrsd/H7Q==",
+      "dev": true,
+      "requires": {
+        "source-map": "0.6.1"
+      }
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -1233,54 +1448,38 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true
-    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "2.0.0",
+        "strip-ansi": "4.0.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "3.0.0"
+      },
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true
-        }
-      }
-    },
-    "strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true
-    },
-    "strip-bom": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-      "dev": true
-    },
-    "strip-indent": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-      "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-      "dev": true,
-      "dependencies": {
-        "get-stdin": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-          "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
           "dev": true
         }
       }
@@ -1292,22 +1491,27 @@
       "dev": true
     },
     "supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-      "dev": true
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+      "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+      "dev": true,
+      "requires": {
+        "has-flag": "2.0.0"
+      }
     },
     "table": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/table/-/table-4.0.1.tgz",
-      "integrity": "sha1-qBFsEz+sLGH0pCCrbN9cTWHw5DU=",
-      "dev": true
-    },
-    "temp-write": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/temp-write/-/temp-write-2.1.0.tgz",
-      "integrity": "sha1-WYkJGODvCdVIqqNC9L00CdhATpY=",
-      "dev": true
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
+      "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+      "dev": true,
+      "requires": {
+        "ajv": "5.3.0",
+        "ajv-keywords": "2.1.1",
+        "chalk": "2.3.0",
+        "lodash": "4.17.4",
+        "slice-ansi": "1.0.0",
+        "string-width": "2.1.1"
+      }
     },
     "text-table": {
       "version": "0.2.0",
@@ -1322,21 +1526,21 @@
       "dev": true
     },
     "tmp": {
-      "version": "0.0.31",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
-      "integrity": "sha1-jzirlDjhcxXl29izZX6L+yd65Kc=",
-      "dev": true
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "1.0.2"
+      }
     },
     "topo": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
-      "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI="
-    },
-    "trim-newlines": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
-      "dev": true
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.0.tgz",
+      "integrity": "sha512-Tlu1fGlR90iCdIPURqPiufqAlCZYzLjHYVVbcFWDMcX7+tK8hdZWAfsMrD/pBul9jqHHwFjNdf1WaxA9vTRRhw==",
+      "requires": {
+        "hoek": "5.0.2"
+      }
     },
     "tryit": {
       "version": "1.0.3",
@@ -1348,7 +1552,10 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2"
+      }
     },
     "typedarray": {
       "version": "0.0.6",
@@ -1361,7 +1568,21 @@
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "source-map": "0.5.7",
+        "uglify-to-browserify": "1.0.2",
+        "yargs": "3.10.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true,
+          "optional": true
+        }
+      }
     },
     "uglify-to-browserify": {
       "version": "1.0.2",
@@ -1376,17 +1597,14 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
-    "uuid": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-      "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
-      "dev": true
-    },
-    "validate-npm-package-license": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-      "dev": true
+    "which": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "dev": true,
+      "requires": {
+        "isexe": "2.0.0"
+      }
     },
     "window-size": {
       "version": "0.1.0",
@@ -1411,12 +1629,15 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "mkdirp": "0.5.1"
+      }
     },
-    "xtend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
     },
     "yargs": {
@@ -1424,7 +1645,13 @@
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
       "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "camelcase": "1.2.1",
+        "cliui": "2.1.0",
+        "decamelize": "1.2.0",
+        "window-size": "0.1.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
   "devDependencies": {
     "code": "5.x.x",
     "lab": "15.x.x",
-    "mongodb": "2.x.x"
+    "mongodb": "3.x.x"
   },
   "peerDependencies": {
-    "mongodb": "2.x.x"
+    "mongodb": "3.x.x"
   },
   "dependencies": {
     "hoek": "5.x.x",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "example": "MONGODB_URI='mongodb://localhost:27017' MONGODB_NAME='mongo-models-test' PORT=8080 node example/server.js",
-    "test": "lab -c -L --assert code"
+    "test": "lab -c -L --assert code",
+    "toc": "hapitoc"
   },
   "repository": {
     "type": "git",
@@ -31,6 +32,7 @@
     "body-parser": "1.x.x",
     "code": "5.x.x",
     "express": "4.x.x",
+    "hapitoc": "1.x.x",
     "lab": "15.x.x",
     "mongodb": "3.x.x"
   },

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "mongo-models",
   "version": "1.4.0",
-  "description": "Map JavaScript classes to MongoDB collections",
+  "description": "JavaScript class interfaces to MongoDB collections",
   "main": "index.js",
   "scripts": {
-    "test": "lab -c -L"
+    "test": "lab -c -L --assert code"
   },
   "repository": {
     "type": "git",
@@ -18,7 +18,7 @@
     "odm"
   ],
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=8.x.x"
   },
   "author": "Reza Akhavan <reza@akhavan.me>",
   "license": "MIT",
@@ -27,18 +27,15 @@
   },
   "homepage": "https://github.com/jedireza/mongo-models",
   "devDependencies": {
-    "code": "4.x.x",
-    "lab": "14.x.x",
-    "mongodb": "2.x.x",
-    "opn-cli": "3.x.x",
-    "proxyquire": "1.x.x"
+    "code": "5.x.x",
+    "lab": "15.x.x",
+    "mongodb": "2.x.x"
   },
   "peerDependencies": {
     "mongodb": "2.x.x"
   },
   "dependencies": {
-    "async": "2.x.x",
-    "hoek": "4.x.x",
-    "joi": "10.x.x"
+    "hoek": "5.x.x",
+    "joi": "13.x.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "JavaScript class interfaces to MongoDB collections",
   "main": "index.js",
   "scripts": {
+    "example": "MONGODB_URI='mongodb://localhost:27017' MONGODB_NAME='mongo-models-test' PORT=8080 node example/server.js",
     "test": "lab -c -L --assert code"
   },
   "repository": {
@@ -27,7 +28,9 @@
   },
   "homepage": "https://github.com/jedireza/mongo-models",
   "devDependencies": {
+    "body-parser": "1.x.x",
     "code": "5.x.x",
+    "express": "4.x.x",
     "lab": "15.x.x",
     "mongodb": "3.x.x"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -418,13 +418,14 @@ lab.experiment('Paged find', () => {
         };
 
         const filter = {};
-        const fields = undefined;
         const limit = 10;
         const page = 1;
-        const sort = { _id: -1 };
+        const options = {
+            sort: { _id: -1 }
+        };
 
         await lab.expect(
-            DummyModel.pagedFind(filter, fields, sort, limit, page)
+            DummyModel.pagedFind(filter, limit, page, options)
         ).to.reject();
 
         DummyModel.count = realCount;
@@ -442,12 +443,13 @@ lab.experiment('Paged find', () => {
         await DummyModel.insertMany(documents);
 
         const filter = {};
-        let fields;
         const limit = 10;
         const page = 1;
-        const sort = { _id: -1 };
+        const options = {
+            sort: { _id: -1 }
+        };
         const result = await DummyModel.pagedFind(
-            filter, fields, sort, limit, page
+            filter, limit, page, options
         );
 
         lab.expect(result).to.be.an.object();
@@ -465,12 +467,13 @@ lab.experiment('Paged find', () => {
         await DummyModel.insertMany(documents);
 
         const filter = {};
-        let fields;
         const limit = 2;
         const page = 1;
-        const sort = { _id: -1 };
+        const options = {
+            sort: { _id: -1 }
+        };
         const result = await DummyModel.pagedFind(
-            filter, fields, sort, limit, page
+            filter, limit, page, options
         );
 
         lab.expect(result).to.be.an.object();
@@ -488,12 +491,13 @@ lab.experiment('Paged find', () => {
         await DummyModel.insertMany(documents);
 
         const filter = { 'role.special': { $exists: true } };
-        let fields;
         const limit = 2;
         const page = 1;
-        const sort = { _id: -1 };
+        const options = {
+            sort: { _id: -1 }
+        };
         const result = await DummyModel.pagedFind(
-            filter, fields, sort, limit, page
+            filter, limit, page, options
         );
 
         lab.expect(result).to.be.an.object();

--- a/test/index.js
+++ b/test/index.js
@@ -7,7 +7,10 @@ const Mongodb = require('mongodb');
 
 const lab = exports.lab = Lab.script();
 const config = {
-    uri: 'mongodb://localhost:27017/mongo-models-test',
+    connection: {
+        uri: 'mongodb://localhost:27017',
+        db: 'mongo-models-test'
+    },
     options: {}
 };
 
@@ -16,7 +19,7 @@ lab.experiment('Connections', () => {
 
     lab.test('it connects and disconnects the database', async () => {
 
-        const db = await MongoModels.connect(config.uri, config.options);
+        const db = await MongoModels.connect(config.connection, config.options);
 
         lab.expect(db).to.be.an.instanceof(Mongodb.Db);
         lab.expect(db.serverConfig.isConnected()).to.equal(true);
@@ -29,16 +32,23 @@ lab.experiment('Connections', () => {
 
     lab.test('it throws when the db connection fails', async () => {
 
-        await lab.expect(MongoModels.connect('mongodb://poison')).to.reject();
+        const connection = {
+            uri: 'mongodb://poison',
+            db: 'pill'
+        };
+
+        await lab.expect(MongoModels.connect(connection)).to.reject();
     });
 
 
     lab.test('it connects to multiple databases', async () => {
 
-        const uri = config.uri;
-        const options = config.options;
-        const db = await MongoModels.connect(uri, options);
-        const db2 = await MongoModels.connect(uri + '2', options, 'alt');
+        const connection2 = {
+            uri: config.connection.uri,
+            db: `${config.connection.db}2`
+        };
+        const db = await MongoModels.connect(config.connection, config.options);
+        const db2 = await MongoModels.connect(connection2, config.options, 'alt');
 
         lab.expect(db).to.be.an.instanceof(Mongodb.Db);
         lab.expect(db2).to.be.an.instanceof(Mongodb.Db);
@@ -61,9 +71,7 @@ lab.experiment('Connections', () => {
 
     lab.test('it binds db functions to a named connection using `with` and caches for subsequent use', async () => {
 
-        const uri = config.uri;
-        const options = config.options;
-        const db = await MongoModels.connect(uri, options, 'named');
+        const db = await MongoModels.connect(config.connection, config.options, 'named');
 
         lab.expect(db).to.be.an.instanceof(Mongodb.Db);
         lab.expect(db.serverConfig.isConnected()).to.equal(true);
@@ -292,7 +300,7 @@ lab.experiment('Indexes', () => {
 
         DummyModel.collectionName = 'dummies';
 
-        await MongoModels.connect(config.uri, config.options);
+        await MongoModels.connect(config.connection, config.options);
     });
 
 
@@ -313,6 +321,17 @@ lab.experiment('Indexes', () => {
 
 
 lab.experiment('Helpers', () => {
+
+    lab.before(async () => {
+
+        await MongoModels.connect(config.connection, config.options);
+    });
+
+    lab.after(() => {
+
+        MongoModels.disconnect();
+    });
+
 
     lab.test('it creates a fields document from a string', () => {
 
@@ -373,7 +392,7 @@ lab.experiment('Paged find', () => {
 
         DummyModel.collectionName = 'dummies';
 
-        await MongoModels.connect(config.uri, config.options);
+        await MongoModels.connect(config.connection, config.options);
     });
 
 
@@ -501,7 +520,7 @@ lab.experiment('Proxy methods', () => {
 
         DummyModel.collectionName = 'dummies';
 
-        await MongoModels.connect(config.uri, config.options);
+        await MongoModels.connect(config.connection, config.options);
     });
 
 


### PR DESCRIPTION
This PR brings us into the `async`/`await` world.

This PR also adds support for multiple db connections via an optional named connection API. So if you only have one connection, or use the default, you connect and call functions like normal:  (Ex: `Model.count({})`). And if you have multiple connections, you can specify the name of the connection when connecting and then use the name via the new `with(...)` method: (Ex: `Model.with('named').count({})`).

Resolves #11 
Resolves #24 
Resolves #27 

TODO:

 - [X] Do the work
 - [X] Update README.md
 - [X] Add example app
 - [X] Update the API docs
 - [x] Document breaking changes
    - [x] The minimum supported driver is `mongodb@3.x.x`
    - [x] Callbacks are gone everything is `async`/`await`.
    - [x] The property `constructWithSchema` has been removed. The default behavior is to always construct with the schema.
    - [x] The constructor will throw if there was a validation error.
    - [x] The property `collection` has been renamed to `collectionName`.
    - [x] The `connect` method now expects a `connection` object with keys `uri` and `db`.
    - [x] The `pagedFind` method no longer accepts the `fields` or `sort` arguments. Use the `options` argument instead.