### PR TITLE
Compatibility with @hapi/joi 16

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const Hoek = require('@hapi/hoek');
-const Joi = require('@hapi/joi');
 const Mongodb = require('mongodb');
 
 

--- a/index.js
+++ b/index.js
@@ -460,13 +460,13 @@ class MongoModels {
 
     static validate(input) {
 
-        return Joi.validate(input, this.schema);
+        return this.schema.validate(input);
     }
 
 
     validate() {
 
-        return Joi.validate(this, this.constructor.schema);
+        return this.constructor.schema.validate(this);
     }
 
 


### PR DESCRIPTION
When using **@hapi/joi** 16.x.x, the following error occurs when instantiating a model. This can be easily reproduced using the Customer example. Simply use joi 16 instead of 15.

Example:
```
    const Customer = require('../models/customer');
    let customers;

    try {
      customers = await Customer.create(name, email, phone);
    } catch (err) {
      console.error(err);
    }
```

Throws error:
```
Error: Invalid schema content: ($_root.alternatives)
    at new module.exports (/home/me/projects/test/node_modules/mongo-models/node_modules/@hapi/joi/node_modules/@hapi/hoek/lib/error.js:23:19)
    at Object.module.exports [as assert] (/home/me/projects/test/node_modules/mongo-models/node_modules/@hapi/joi/node_modules/@hapi/hoek/lib/assert.js:20:11)
    at Object.exports.schema (/home/me/projects/test/node_modules/mongo-models/node_modules/@hapi/joi/lib/cast.js:50:10)
    at internals.Object.keys (/home/me/projects/test/node_modules/mongo-models/node_modules/@hapi/joi/lib/types/object/index.js:363:35)
    at Object.exports.schema (/home/me/projects/test/node_modules/mongo-models/node_modules/@hapi/joi/lib/cast.js:31:29)
    at internals.Object.keys (/home/me/projects/test/node_modules/mongo-models/node_modules/@hapi/joi/lib/types/object/index.js:363:35)
    at Object.exports.schema (/home/me/projects/test/node_modules/mongo-models/node_modules/@hapi/joi/lib/cast.js:31:29)
    at module.exports.internals.Any.root.compile (/home/me/projects/test/node_modules/mongo-models/node_modules/@hapi/joi/lib/index.js:157:25)
    at module.exports.internals.Any.root.validate (/home/me/projects/test/node_modules/mongo-models/node_modules/@hapi/joi/lib/index.js:143:29)
    at Function.validate (/home/me/projects/test/node_modules/mongo-models/index.js:463:20) {
  path: '$_root.alternatives'
}
```
Joi validate() method has changed in v16 and the following small changes resolve the issue. Based on some quick tests, this change is also backwards compatible with v15.
